### PR TITLE
/getitem GM command item count fix

### DIFF
--- a/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
@@ -37,14 +37,24 @@ namespace Imgeneus.World.Game.Player
             if (!IsAdmin)
                 return;
 
-            var item = AddItemToInventory(new Item(_databasePreloader, gMGetItemPacket.Type, gMGetItemPacket.TypeId, gMGetItemPacket.Count));
-            if (item != null)
+            byte itemCount = gMGetItemPacket.Count;
+
+            while (itemCount > 0)
             {
-                _packetsHelper.SendAddItem(Client, item);
-                _packetsHelper.SendGmCommandSuccess(Client);
+                var newItem = new Item(_databasePreloader, gMGetItemPacket.Type, gMGetItemPacket.TypeId,
+                    itemCount);
+
+                var item = AddItemToInventory(newItem);
+                if (item != null)
+                {
+                    _packetsHelper.SendAddItem(Client, item);
+                    _packetsHelper.SendGmCommandSuccess(Client);
+                }
+                else
+                    _packetsHelper.SendGmCommandError(Client, PacketType.GM_COMMAND_GET_ITEM);
+
+                itemCount -= newItem.Count;
             }
-            else
-                _packetsHelper.SendGmCommandError(Client, PacketType.GM_COMMAND_GET_ITEM);
         }
 
         private void HandlePlayerInTarget(PlayerInTargetPacket packet)

--- a/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
@@ -37,7 +37,7 @@ namespace Imgeneus.World.Game.Player
             if (!IsAdmin)
                 return;
 
-            byte itemCount = gMGetItemPacket.Count;
+            var itemCount = gMGetItemPacket.Count;
 
             while (itemCount > 0)
             {

--- a/src/Imgeneus.World/Game/Player/Item.cs
+++ b/src/Imgeneus.World/Game/Player/Item.cs
@@ -68,8 +68,9 @@ namespace Imgeneus.World.Game.Player
             if (Type != 0 && TypeId != 0 && Type != MONEY_ITEM_TYPE)
             {
                 _dbItem = _databasePreloader.Items[(Type, TypeId)];
-                // Prevent Count from exceeding MaxCount
-                Count = count > MaxCount ? MaxCount : count;
+                // Prevent Count from exceeding MaxCount and from being 0 (zero)
+                var newCount = count > MaxCount ? MaxCount : count;
+                Count = newCount < 1 ? (byte)1 : newCount;
             }
         }
 

--- a/src/Imgeneus.World/Game/Player/Item.cs
+++ b/src/Imgeneus.World/Game/Player/Item.cs
@@ -31,7 +31,7 @@ namespace Imgeneus.World.Game.Player
         public Gem Gem6;
 
         public byte Count;
-        
+
         public Item(IDatabasePreloader databasePreloader, DbCharacterItems dbItem) : this(databasePreloader, dbItem.Type, dbItem.TypeId, dbItem.Count)
         {
             Bag = dbItem.Bag;

--- a/src/Imgeneus.World/Game/Player/Item.cs
+++ b/src/Imgeneus.World/Game/Player/Item.cs
@@ -31,7 +31,7 @@ namespace Imgeneus.World.Game.Player
         public Gem Gem6;
 
         public byte Count;
-
+        
         public Item(IDatabasePreloader databasePreloader, DbCharacterItems dbItem) : this(databasePreloader, dbItem.Type, dbItem.TypeId, dbItem.Count)
         {
             Bag = dbItem.Bag;
@@ -66,7 +66,11 @@ namespace Imgeneus.World.Game.Player
             Count = count;
 
             if (Type != 0 && TypeId != 0 && Type != MONEY_ITEM_TYPE)
+            {
                 _dbItem = _databasePreloader.Items[(Type, TypeId)];
+                // Prevent Count from exceeding MaxCount
+                Count = count > MaxCount ? MaxCount : count;
+            }
         }
 
         #region Trade


### PR DESCRIPTION
DBItem's Count wasn't being checked before attempting to give items to a player, which resulted in unexpected behavior. I added a check on the Item item itself, to prevent the Count field to surpass the MaxCount field and also a simple fix on the CharacterPacketHandler file to get the expected behaviour.

![ezgif-4-002ba872c7e1](https://user-images.githubusercontent.com/32178801/100524725-355d5b00-3199-11eb-86c0-aee73477cf33.gif)
