### PR TITLE
Add weapon check on auto attack

### DIFF
--- a/src/Imgeneus.World/Game/Player/CharacterAttack.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterAttack.cs
@@ -329,6 +329,12 @@ namespace Imgeneus.World.Game.Player
                 return CanUseSkill(skill, target);
             }
 
+            if (Weapon is null)
+            {
+                SendAutoAttackWrongEquipment(target);
+                return false;
+            }
+
             return true;
         }
 

--- a/src/Imgeneus.World/Game/Player/CharacterPacketSenders.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketSenders.cs
@@ -59,6 +59,9 @@ namespace Imgeneus.World.Game.Player
 
         private void SendAutoAttackWrongTarget(IKillable target) => _packetsHelper.SendAutoAttackWrongTarget(Client, this, target);
 
+        private void SendAutoAttackWrongEquipment(IKillable target) =>
+            _packetsHelper.SendAutoAttackWrongEquipment(Client, this, target);
+
         private void SendAutoAttackCanNotAttack(IKillable target) => _packetsHelper.SendAutoAttackCanNotAttack(Client, this, target);
 
         private void SendSkillAttackCanNotAttack(IKillable target, Skill skill) => _packetsHelper.SendSkillAttackCanNotAttack(Client, this, skill, target);

--- a/src/Imgeneus.World/Packets/PacketsHelper.cs
+++ b/src/Imgeneus.World/Packets/PacketsHelper.cs
@@ -192,6 +192,14 @@ namespace Imgeneus.World.Packets
             client.SendPacket(packet);
         }
 
+        internal void SendAutoAttackWrongEquipment(IWorldClient client, Character sender, IKillable target)
+        {
+            PacketType type = target is Character ? PacketType.CHARACTER_CHARACTER_AUTO_ATTACK : PacketType.CHARACTER_MOB_AUTO_ATTACK;
+            using var packet = new Packet(type);
+            packet.Write(new UsualAttack(sender.Id, 0, new AttackResult() { Success = AttackSuccess.WrongEquipment }).Serialize());
+            client.SendPacket(packet);
+        }
+
         internal void SendAutoAttackCanNotAttack(IWorldClient client, Character sender, IKillable target)
         {
             PacketType type = target is Character ? PacketType.CHARACTER_CHARACTER_AUTO_ATTACK : PacketType.CHARACTER_MOB_AUTO_ATTACK;


### PR DESCRIPTION
Weapon check was already done on skill use but was missing on auto attack, this caused the undesired behavior of player running non-stop when trying to attack without an equipped weapon.

A difference I noticed between EP4 and EP8 is that in EP4 when the game receives the `AutoAttackWrongEquipment` packet, it stops trying to auto attack, whereas in EP8, it keeps trying to attack and receives the `Unavailable equipment` message repeatedly until the user manually stops the attack action. Maybe EP8 needs an extra packet sent to the client? I checked all received packets for EP4 and we're already sending them all to the client as far as I'm concerned.