### PR TITLE
implement name change stone

### DIFF
--- a/src/Imgeneus.DatabaseBackgroundService/Handlers/ActionType.cs
+++ b/src/Imgeneus.DatabaseBackgroundService/Handlers/ActionType.cs
@@ -39,6 +39,7 @@
 
         // Appearance
         SAVE_APPEARANCE,
+        SAVE_IS_RENAME,
 
         // Friends
         SAVE_FRIENDS,

--- a/src/Imgeneus.DatabaseBackgroundService/Handlers/DatabaseFactoryHandler.cs
+++ b/src/Imgeneus.DatabaseBackgroundService/Handlers/DatabaseFactoryHandler.cs
@@ -437,5 +437,19 @@ namespace Imgeneus.DatabaseBackgroundService.Handlers
 
             await database.SaveChangesAsync();
         }
+
+        [ActionHandler(ActionType.SAVE_IS_RENAME)]
+        internal static async Task SaveRename(object[] args)
+        {
+            int characterId = (int)args[0];
+            bool isRename = (bool)args[1];
+
+            using var database = DependencyContainer.Instance.Resolve<IDatabase>();
+            var character = database.Characters.Find(characterId);
+
+            character.IsRename = isRename;
+
+            await database.SaveChangesAsync();
+        }
     }
 }

--- a/src/Imgeneus.Network/Packets/Game/RenameCharacterPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/RenameCharacterPacket.cs
@@ -1,0 +1,22 @@
+using Imgeneus.Network.Data;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public struct RenameCharacterPacket : IDeserializedPacket
+    {
+        public int CharacterId;
+        public string NewName;
+
+        public RenameCharacterPacket(IPacketStream packet)
+        {
+            CharacterId = packet.Read<int>();
+            NewName = packet.ReadString(21);
+        }
+
+        public void Deconstruct(out int characterId, out string newName)
+        {
+            characterId = CharacterId;
+            newName = NewName;
+        }
+    }
+}

--- a/src/Imgeneus.World/Game/Player/CharacterInventory.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterInventory.cs
@@ -959,6 +959,11 @@ namespace Imgeneus.World.Game.Player
                     // Some herbs do not have HealingPotion effect, but still they heal.
                     UseHealingPotion(item);
                     break;
+
+                case SpecialEffect.NameChange:
+                    UseNameChangeStone();
+                    break;
+
                 default:
                     _logger.LogError($"Uninplemented item effect {item.Special}.");
                     break;
@@ -987,6 +992,16 @@ namespace Imgeneus.World.Game.Player
             _taskQueue.Enqueue(ActionType.SAVE_APPEARANCE, Id, Face, Hair, Height, Gender);
 
             OnAppearanceChanged?.Invoke(this);
+        }
+
+        /// <summary>
+        /// Initiates name change process
+        /// </summary>
+        public void UseNameChangeStone()
+        {
+            IsRename = true;
+
+            _taskQueue.Enqueue(ActionType.SAVE_IS_RENAME, Id, true);
         }
 
         /// <summary>

--- a/src/Imgeneus.World/Game/Player/CharacterStats.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterStats.cs
@@ -34,6 +34,7 @@ namespace Imgeneus.World.Game.Player
         public ushort Victories { get; set; }
         public ushort Defeats { get; set; }
         public bool IsAdmin { get; set; }
+        public bool IsRename { get; set; }
 
         private byte[] _nameAsByteArray;
         public byte[] NameAsByteArray

--- a/src/Imgeneus.World/SelectionScreen/SelectionScreenManager.cs
+++ b/src/Imgeneus.World/SelectionScreen/SelectionScreenManager.cs
@@ -290,7 +290,7 @@ namespace Imgeneus.World.SelectionScreen
                 return;
 
             // Check that name isn't in use
-            var characterWithNewName = await database.Characters.FirstOrDefaultAsync(c => c.UserId == _client.UserID && c.Name == newName);
+            var characterWithNewName = await database.Characters.FirstOrDefaultAsync(c => c.Name == newName);
 
             using var packet = new Packet(PacketType.RENAME_CHARACTER);
 

--- a/src/Imgeneus.World/Serialization/CharacterSelectionScreen.cs
+++ b/src/Imgeneus.World/Serialization/CharacterSelectionScreen.cs
@@ -98,7 +98,10 @@ namespace Imgeneus.Network.Serialization
         public bool IsDelete;
 
         [FieldOrder(29)]
-        public byte[] UnknownBytes2 = new byte[25];
+        public bool IsRename;
+
+        [FieldOrder(30)]
+        public byte[] UnknownBytes2 = new byte[24];
 
         public CharacterSelectionScreen(DbCharacter character)
         {
@@ -121,6 +124,7 @@ namespace Imgeneus.Network.Serialization
             HealthPoints = character.HealthPoints;
             ManaPoints = character.ManaPoints;
             StaminaPoints = character.StaminaPoints;
+            IsRename = character.IsRename;
 
             var equipmentItems = character.Items.Where(item => item.Bag == 0);
             for (var i = 0; i < 17; i++)

--- a/src/Imgeneus.World/WorldClient.cs
+++ b/src/Imgeneus.World/WorldClient.cs
@@ -192,7 +192,8 @@ namespace Imgeneus.World
             { PacketType.ITEM_COMPOSE_ABSOLUTE, (s) => new ItemComposeAbsolutePacket(s) },
             { PacketType.ITEM_COMPOSE, (s) => new ItemComposePacket(s) },
             { PacketType.ITEM_COMPOSE_ABSOLUTE_SELECT, (s) => new ItemComposeAbsoluteSelectPacket(s) },
-            { PacketType.UPDATE_STATS, (s) => new UpdateStatsPacket(s) }
+            { PacketType.UPDATE_STATS, (s) => new UpdateStatsPacket(s) },
+            { PacketType.RENAME_CHARACTER, (s) => new RenameCharacterPacket(s) }
         };
 
         /// <inheritdoc />


### PR DESCRIPTION
This PR implements all the name change process.
Client asks for name change -> Character database field `IsRename` is set to true -> When user goes to character screen he will be prompted to set a new name -> server will validate if name is on use -> send success/error packet to client -> set new name and save it to database.
The response statuses for the name change that I found are  1 = success, 2 = name already in use... I don't know what 0 means (if it means something) but I'll try to find out if there are some other status codes. For the moment, this works fine for the mentioned cases.