### PR TITLE
Notice Manager

### DIFF
--- a/src/Imgeneus.Network/Packets/Game/GMNoticeAdminsPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/GMNoticeAdminsPacket.cs
@@ -1,0 +1,16 @@
+using Imgeneus.Network.Data;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public struct GMNoticeAdminsPacket : IDeserializedPacket
+    {
+        public string Message;
+
+        public GMNoticeAdminsPacket(IPacketStream packet)
+        {
+            var messageLength = packet.Read<byte>();
+            // Message always ends with an empty character
+            Message = packet.ReadString(messageLength - 1);
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/Game/GMNoticeFactionPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/GMNoticeFactionPacket.cs
@@ -1,0 +1,18 @@
+using Imgeneus.Network.Data;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public struct GMNoticeFactionPacket : IDeserializedPacket
+    {
+        public short TimeInterval;
+        public string Message;
+
+        public GMNoticeFactionPacket(IPacketStream packet)
+        {
+            TimeInterval = packet.Read<short>();
+            var messageLength = packet.Read<byte>();
+            // Message always ends with an empty character
+            Message = packet.ReadString(messageLength - 1);
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/Game/GMNoticeMapPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/GMNoticeMapPacket.cs
@@ -1,0 +1,18 @@
+using Imgeneus.Network.Data;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public struct GMNoticeMapPacket : IDeserializedPacket
+    {
+        public short TimeInterval;
+        public string Message;
+
+        public GMNoticeMapPacket(IPacketStream packet)
+        {
+            TimeInterval = packet.Read<short>();
+            var messageLength = packet.Read<byte>();
+            // Message always ends with an empty character
+            Message = packet.ReadString(messageLength - 1);
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/Game/GMNoticePlayerPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/GMNoticePlayerPacket.cs
@@ -1,0 +1,20 @@
+using Imgeneus.Network.Data;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public struct GMNoticePlayerPacket : IDeserializedPacket
+    {
+        public string TargetName;
+        public short TimeInterval;
+        public string Message;
+
+        public GMNoticePlayerPacket(IPacketStream packet)
+        {
+            TargetName = packet.ReadString(21);
+            TimeInterval = packet.Read<short>();
+            var messageLength = packet.Read<byte>();
+            // Message always ends with an empty character
+            Message = packet.ReadString(messageLength - 1);
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/Game/GMNoticeWorldPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/GMNoticeWorldPacket.cs
@@ -1,0 +1,18 @@
+using Imgeneus.Network.Data;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public struct GMNoticeWorldPacket : IDeserializedPacket
+    {
+        public short TimeInterval;
+        public string Message;
+
+        public GMNoticeWorldPacket(IPacketStream packet)
+        {
+            TimeInterval = packet.Read<short>();
+            var messageLength = packet.Read<byte>();
+            // Message always ends with an empty character
+            Message = packet.ReadString(messageLength - 1);
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/PacketType.cs
+++ b/src/Imgeneus.Network/Packets/PacketType.cs
@@ -30,7 +30,7 @@
         SERVER_LIST = 0xA201,
         SELECT_SERVER = 0xA202,
 
-        // Game 
+        // Game
         GAME_HANDSHAKE = 0xA301,
         PING = 0xA303,
         CASH_POINT = 0x2605, // 9733
@@ -190,6 +190,13 @@
         CHAT_PARTY = 0x1105, // 4357
         CHAT_ANOUNCEMENT = 0x1108, // 4360
         CHAT_MAP = 0x1111, // 4369
+
+        // Notice
+        NOTICE_WORLD = 0xF90B, // 63755
+        NOTICE_FACTION = 0xF907, // 63751
+        NOTICE_PLAYER = 0xF908, // 63752
+        NOTICE_MAP = 0xF909, // 63753
+        NOTICE_ADMINS = 0xF906, // 63750
 
         // Duel
         DUEL_REQUEST = 0x2401, // 9217

--- a/src/Imgeneus.World/Game/Notice/INoticeManager.cs
+++ b/src/Imgeneus.World/Game/Notice/INoticeManager.cs
@@ -1,0 +1,57 @@
+﻿using Imgeneus.Database.Entities;
+
+namespace Imgeneus.World.Game.Notice
+{
+    public interface INoticeManager
+    {
+        /// <summary>
+        /// Sends a notice to all online players.
+        /// Optionally, the notice can be repeated periodically specifying a time interval in seconds.
+        /// </summary>
+        /// <param name="message">Notice message</param>
+        /// <param name="timeInterval">Time interval in seconds</param>
+        public void SendWorldNotice(string message, short timeInterval = 0);
+
+        /// <summary>
+        /// Sends a notice to all online players that belong to a specified faction.
+        /// Optionally, the notice can be repeated periodically specifying a time interval in seconds.
+        /// </summary>
+        /// <param name="message">Notice message</param>
+        /// <param name="faction">Target faction</param>
+        /// <param name="timeInterval">Time interval in seconds</param>
+        public void SendFactionNotice(string message, Fraction faction, short timeInterval = 0);
+
+        /// <summary>
+        /// Sends a notice to all online players that are located in a specific map.
+        /// Optionally, the notice can be repeated periodically specifying a time interval in seconds.
+        /// </summary>
+        /// <param name="message">Notice message</param>
+        /// <param name="mapId">Target map</param>
+        /// <param name="timeInterval">Time interval in seconds</param>
+        public void SendMapNotice(string message, ushort mapId, short timeInterval = 0);
+
+        /// <summary>
+        /// Attempts to send a notice to a specific player.
+        /// Optionally, the notice can be repeated periodically specifying a time interval in seconds.
+        /// </summary>
+        /// <param name="message">Notice message</param>
+        /// <param name="targetPlayer">Target player's name</param>
+        /// <param name="timeInterval">Time interval in seconds</param>
+        /// <returns>Success status indicating whether the notice was sent or not. It will fail when the target player is offline.</returns>
+        public bool TrySendPlayerNotice(string message, string targetPlayer, short timeInterval = 0);
+
+        /// <summary>
+        /// Sends a notice to all online admin players.
+        /// </summary>
+        /// <param name="message">Notice message</param>
+        public void SendAdminNotice(string message);
+
+        /// <summary>
+        /// Sends a notice to all online players within the map cell that contains specific coordinates.
+        /// </summary>
+        /// <param name="message">Notice message</param>
+        /// <param name="posX">X coordinate</param>
+        /// <param name="posZ">Z coordinate</param>
+        public void SendAreaNotice(string message, ushort posX, ushort posZ);
+    }
+}

--- a/src/Imgeneus.World/Game/Notice/NoticeManager.cs
+++ b/src/Imgeneus.World/Game/Notice/NoticeManager.cs
@@ -1,0 +1,106 @@
+﻿using System.Linq;
+using Imgeneus.Database.Entities;
+using Imgeneus.Network.Data;
+using Imgeneus.Network.Packets;
+using Imgeneus.World.Game.Player;
+using Microsoft.Extensions.Logging;
+
+namespace Imgeneus.World.Game.Notice
+{
+    public class NoticeManager : INoticeManager
+    {
+        private readonly ILogger<INoticeManager> _logger;
+        private readonly IGameWorld _gameWorld;
+
+        public NoticeManager(ILogger<INoticeManager> logger, IGameWorld gameWorld)
+        {
+            _logger = logger;
+            _gameWorld = gameWorld;
+        }
+
+        /// <inheritdoc/>
+        // TODO: Implement notice timer with time interval
+        public void SendWorldNotice(string message, short timeInterval = 0)
+        {
+            var worldPlayers = _gameWorld.Players.Values;
+
+            foreach (var player in worldPlayers)
+            {
+                SendNoticeToPlayer(player, PacketType.NOTICE_WORLD, message);
+            }
+        }
+
+        /// <inheritdoc/>
+        // TODO: Implement notice timer with time interval
+        public void SendFactionNotice(string message, Fraction faction, short timeInterval = 0)
+        {
+            var factionPlayers = _gameWorld.Players.Values.Where(p => p.Country == faction);
+
+            foreach (var player in factionPlayers)
+            {
+                SendNoticeToPlayer(player, PacketType.NOTICE_FACTION, message);
+            }
+        }
+
+        /// <inheritdoc/>
+        // TODO: Implement notice timer with time interval
+        public void SendMapNotice(string message, ushort mapId, short timeInterval = 0)
+        {
+            var mapPlayers = _gameWorld.Players.Values.Where(p => p.MapId == mapId);
+
+            foreach (var player in mapPlayers)
+            {
+                SendNoticeToPlayer(player, PacketType.NOTICE_MAP, message);
+            }
+        }
+
+        /// <inheritdoc/>
+        // TODO: Implement notice timer with time interval
+        public bool TrySendPlayerNotice(string message, string targetPlayer, short timeInterval = 0)
+        {
+            var target = _gameWorld.Players.Values.FirstOrDefault(p => p.Name == targetPlayer);
+
+            if (target == null)
+                return false;
+
+            SendNoticeToPlayer(target, PacketType.NOTICE_PLAYER, message);
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public void SendAdminNotice(string message)
+        {
+            var admins = _gameWorld.Players.Values.Where(p => p.IsAdmin);
+
+            foreach (var player in admins)
+            {
+                SendNoticeToPlayer(player, PacketType.NOTICE_ADMINS, message);
+            }
+        }
+
+        /// <inheritdoc/>
+        // TODO: Find out the correct parameters for /bnotice command and implement it here.
+        public void SendAreaNotice(string message, ushort posX, ushort posZ)
+        {
+            _logger.LogError("Area notice is not implemented yet. Notice failed.");
+        }
+
+        #region Senders
+
+        /// <summary>
+        /// Sends a notice to a player
+        /// </summary>
+        /// <param name="character">Receiver character</param>
+        /// <param name="noticeType">Notice type</param>
+        /// <param name="message">Notice's message text</param>
+        private void SendNoticeToPlayer(Character character, PacketType noticeType, string message)
+        {
+            using var packet = new Packet(noticeType);
+            packet.WriteByte((byte) message.Length);
+            packet.Write(message);
+            character.Client.SendPacket(packet);
+        }
+
+        #endregion
+    }
+}

--- a/src/Imgeneus.World/Game/Player/Character.cs
+++ b/src/Imgeneus.World/Game/Player/Character.cs
@@ -1,5 +1,4 @@
-﻿using Imgeneus.Core.DependencyInjection;
-using Imgeneus.Database;
+﻿using Imgeneus.Database;
 using Imgeneus.Database.Constants;
 using Imgeneus.Database.Entities;
 using Imgeneus.Database.Preload;
@@ -19,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Imgeneus.World.Game.Notice;
 
 namespace Imgeneus.World.Game.Player
 {
@@ -34,6 +34,7 @@ namespace Imgeneus.World.Game.Player
         private readonly IDyeingManager _dyeingManager;
         private readonly IMobFactory _mobFactory;
         private readonly INpcFactory _npcFactory;
+        private readonly INoticeManager _noticeManager;
 
         public Character(ILogger<Character> logger,
                          IGameWorld gameWorld,
@@ -44,7 +45,8 @@ namespace Imgeneus.World.Game.Player
                          ILinkingManager linkinManager,
                          IDyeingManager dyeingManager,
                          IMobFactory mobFactory,
-                         INpcFactory npcFactory) : base(databasePreloader)
+                         INpcFactory npcFactory,
+                         INoticeManager noticeManager) : base(databasePreloader)
         {
             _logger = logger;
             _gameWorld = gameWorld;
@@ -55,7 +57,7 @@ namespace Imgeneus.World.Game.Player
             _dyeingManager = dyeingManager;
             _mobFactory = mobFactory;
             _npcFactory = npcFactory;
-
+            _noticeManager = noticeManager;
             _packetsHelper = new PacketsHelper();
 
             _castTimer.Elapsed += CastTimer_Elapsed;
@@ -330,9 +332,9 @@ namespace Imgeneus.World.Game.Player
         /// <summary>
         /// Creates character from database information.
         /// </summary>
-        public static Character FromDbCharacter(DbCharacter dbCharacter, ILogger<Character> logger, IGameWorld gameWorld, ICharacterConfiguration characterConfig, IBackgroundTaskQueue taskQueue, IDatabasePreloader databasePreloader, IChatManager chatManager, ILinkingManager linkingManager, IDyeingManager dyeingManager, IMobFactory mobFactory, INpcFactory npcFactory)
+        public static Character FromDbCharacter(DbCharacter dbCharacter, ILogger<Character> logger, IGameWorld gameWorld, ICharacterConfiguration characterConfig, IBackgroundTaskQueue taskQueue, IDatabasePreloader databasePreloader, IChatManager chatManager, ILinkingManager linkingManager, IDyeingManager dyeingManager, IMobFactory mobFactory, INpcFactory npcFactory, INoticeManager noticeManager)
         {
-            var character = new Character(logger, gameWorld, characterConfig, taskQueue, databasePreloader, chatManager, linkingManager, dyeingManager, mobFactory, npcFactory)
+            var character = new Character(logger, gameWorld, characterConfig, taskQueue, databasePreloader, chatManager, linkingManager, dyeingManager, mobFactory, npcFactory, noticeManager)
             {
                 Id = dbCharacter.Id,
                 Name = dbCharacter.Name,

--- a/src/Imgeneus.World/Game/Player/CharacterNetwork.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterNetwork.cs
@@ -1,11 +1,9 @@
-﻿using Imgeneus.Core.DependencyInjection;
-using Imgeneus.Database.Constants;
+﻿using Imgeneus.Database.Constants;
 using Imgeneus.Network.Data;
 using Imgeneus.Network.Packets;
 using Imgeneus.Network.Packets.Game;
 using Imgeneus.Network.Server;
 using Imgeneus.World.Game.Monster;
-using Imgeneus.World.Game.NPCs;
 using Imgeneus.World.Game.Zone;
 using Microsoft.Extensions.Logging;
 using System;
@@ -392,6 +390,49 @@ namespace Imgeneus.World.Game.Player
                     if (!IsAdmin)
                         return;
                     HandleGMSetAttributePacket(gmSetAttributePacket);
+                    break;
+
+                case GMNoticeWorldPacket gmNoticeWorldPacket:
+                    if (!IsAdmin)
+                        return;
+
+                    _noticeManager.SendWorldNotice(gmNoticeWorldPacket.Message, gmNoticeWorldPacket.TimeInterval);
+                    _packetsHelper.SendGmCommandSuccess(Client);
+                    break;
+
+                case GMNoticePlayerPacket gmNoticePlayerPacket:
+                    if (!IsAdmin)
+                        return;
+
+                    if(_noticeManager.TrySendPlayerNotice(gmNoticePlayerPacket.Message, gmNoticePlayerPacket.TargetName,
+                        gmNoticePlayerPacket.TimeInterval))
+                        _packetsHelper.SendGmCommandSuccess(Client);
+                    else
+                        _packetsHelper.SendGmCommandError(Client, PacketType.NOTICE_PLAYER);
+                    break;
+
+                case GMNoticeFactionPacket gmNoticeFactionPacket:
+                    if (!IsAdmin)
+                        return;
+
+                    _noticeManager.SendFactionNotice(gmNoticeFactionPacket.Message, this.Country, gmNoticeFactionPacket.TimeInterval);
+                    _packetsHelper.SendGmCommandSuccess(Client);
+                    break;
+
+                case GMNoticeMapPacket gmNoticeMapPacket:
+                    if (!IsAdmin)
+                        return;
+
+                    _noticeManager.SendMapNotice(gmNoticeMapPacket.Message, this.MapId, gmNoticeMapPacket.TimeInterval);
+                    _packetsHelper.SendGmCommandSuccess(Client);
+                    break;
+
+                case GMNoticeAdminsPacket gmNoticeAdminsPacket:
+                    if (!IsAdmin)
+                        return;
+
+                    _noticeManager.SendAdminNotice(gmNoticeAdminsPacket.Message);
+                    _packetsHelper.SendGmCommandSuccess(Client);
                     break;
             }
         }

--- a/src/Imgeneus.World/Game/Player/Factory/CharacterFactory.cs
+++ b/src/Imgeneus.World/Game/Player/Factory/CharacterFactory.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
+using Imgeneus.World.Game.Notice;
 
 namespace Imgeneus.World.Game.Player
 {
@@ -59,7 +60,8 @@ namespace Imgeneus.World.Game.Player
                                         scopedProvider.GetService<ILinkingManager>(),
                                         scopedProvider.GetService<IDyeingManager>(),
                                         scopedProvider.GetService<IMobFactory>(),
-                                        scopedProvider.GetService<INpcFactory>());
+                                        scopedProvider.GetService<INpcFactory>(),
+                                        scopedProvider.GetService<INoticeManager>());
             player.Client = client;
             return player;
         }

--- a/src/Imgeneus.World/WorldClient.cs
+++ b/src/Imgeneus.World/WorldClient.cs
@@ -194,7 +194,12 @@ namespace Imgeneus.World
             { PacketType.ITEM_COMPOSE_ABSOLUTE_SELECT, (s) => new ItemComposeAbsoluteSelectPacket(s) },
             { PacketType.UPDATE_STATS, (s) => new UpdateStatsPacket(s) },
             { PacketType.CHARACTER_ATTRIBUTE_SET, (s) => new GMSetAttributePacket(s) },
-            { PacketType.RENAME_CHARACTER, (s) => new RenameCharacterPacket(s) }
+            { PacketType.RENAME_CHARACTER, (s) => new RenameCharacterPacket(s) },
+            { PacketType.NOTICE_WORLD, (s) => new GMNoticeWorldPacket(s) },
+            { PacketType.NOTICE_PLAYER, (s) => new GMNoticePlayerPacket(s) },
+            { PacketType.NOTICE_FACTION, (s) => new GMNoticeFactionPacket(s) },
+            { PacketType.NOTICE_MAP, (s) => new GMNoticeMapPacket(s) },
+            { PacketType.NOTICE_ADMINS, (s) => new GMNoticeAdminsPacket(s) }
         };
 
         /// <inheritdoc />

--- a/src/Imgeneus.World/WorldServerStartup.cs
+++ b/src/Imgeneus.World/WorldServerStartup.cs
@@ -1,5 +1,4 @@
-﻿using Imgeneus.Core.Helpers;
-using Imgeneus.Core.Structures.Configuration;
+﻿using Imgeneus.Core.Structures.Configuration;
 using Imgeneus.Database;
 using Imgeneus.Database.Preload;
 using Imgeneus.DatabaseBackgroundService;
@@ -9,6 +8,7 @@ using Imgeneus.World.Game.Chat;
 using Imgeneus.World.Game.Dyeing;
 using Imgeneus.World.Game.Linking;
 using Imgeneus.World.Game.Monster;
+using Imgeneus.World.Game.Notice;
 using Imgeneus.World.Game.NPCs;
 using Imgeneus.World.Game.Player;
 using Imgeneus.World.Game.Zone;
@@ -64,6 +64,7 @@ namespace Imgeneus.World
                 }
             });
             services.AddSingleton<IChatManager, ChatManager>();
+            services.AddSingleton<INoticeManager, NoticeManager>();
 
             services.AddTransient<ILogsDatabase, LogsDbContext>();
             services.AddTransient<ILinkingManager, LinkingManager>();

--- a/src/UnitTests/Imgeneus.World.Tests/BaseTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/BaseTest.cs
@@ -15,6 +15,7 @@ using Imgeneus.World.Game.Zone.Obelisks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Collections.Generic;
+using Imgeneus.World.Game.Notice;
 
 namespace Imgeneus.World.Tests
 {
@@ -34,6 +35,7 @@ namespace Imgeneus.World.Tests
         protected Mock<IMobFactory> mobFactoryMock = new Mock<IMobFactory>();
         protected Mock<INpcFactory> npcFactoryMock = new Mock<INpcFactory>();
         protected Mock<IObeliskFactory> obeliskFactoryMock = new Mock<IObeliskFactory>();
+        protected Mock<INoticeManager> noticeManagerMock = new Mock<INoticeManager>();
 
         protected Map testMap => new Map(
                     Map.TEST_MAP_ID,
@@ -47,7 +49,7 @@ namespace Imgeneus.World.Tests
 
         protected Character CreateCharacter(Map map = null)
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, linkingMock.Object, dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, linkingMock.Object, dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             if (map != null)

--- a/src/UnitTests/Imgeneus.World.Tests/GemLinkingTests/GemLinkingTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/GemLinkingTests/GemLinkingTest.cs
@@ -11,7 +11,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("It should be possible to link gem.")]
         public void GemAdd_LinkWithPerfectHammer()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -38,7 +38,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("When linking fails, it should not break item, if gem ReqVg is 0. Gem should disappear after linking.")]
         public void GemAdd_FailNotBreakItem()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -63,7 +63,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("When linking fails, it should break item, if gem ReqVg is 1. Gem and item should disappear after linking.")]
         public void GemAdd_FailBreakItem()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -85,7 +85,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("When linking gem to the item, that is on character, this should influence extra stats.")]
         public void GemAdd_ItemIsOnCharacter()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -116,7 +116,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("When linking gem to the item, that is on character, fails (i.e. item is destroyed) this should influence extra stats.")]
         public void GemAdd_ItemIsOnCharacterBreak()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -139,7 +139,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("Linking the same gems is forbidden")]
         public void GemAdd_SameGemsAreForbidden()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -177,7 +177,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("Linking different gems is ok")]
         public void GemAdd_DifferentGemsIsOK()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -212,7 +212,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("Linking should be possible only, if item has free slots.")]
         public void GemAdd_ItemMustHaveFreeSlots()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, WaterArmor.Type, WaterArmor.TypeId));
@@ -240,7 +240,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("Lucky charm can save item, if it's in inventory.")]
         public void GemAdd_LuckyCharmSavesItem()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -267,7 +267,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("Lucky charm is used only, when it's needed.")]
         public void GemAdd_LuckyCharmUsedOnlyWhenNeeded()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             character.AddItemToInventory(new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId));
@@ -297,7 +297,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("It should be possible to exctract gem.")]
         public void GemRemove_ExtractWithPerfectHammer()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             var armorItem = new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId)
@@ -324,7 +324,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("It should be possible to exctract several gems without hammer. Extracted gems are added to inventory.")]
         public void GemRemove_ExtractWithoutPerfectHammer()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             var armorItem = new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId)
@@ -364,7 +364,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("Extracting gem without hammer may break item, if gem ReqVg is 1. ")]
         public void GemRemove_ExtractWithoutPerfectHammerBreaksItem()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             var armorItem = new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId)
@@ -387,7 +387,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("When extracting gem from the item, that is on character, this should influence extra stats.")]
         public void GemRemove_ItemIsOnCharacter()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             var armorItem = new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId)
@@ -408,7 +408,7 @@ namespace Imgeneus.World.Tests.GemLinkingTests
         [Description("When extracting gem from the item, that is on character, this should influence extra stats. If gem ReqVg = 1, item should be broken.")]
         public void GemRemove_ItemIsOnCharacterBreakItem()
         {
-            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object);
+            var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, new LinkingManager(databasePreloader.Object), dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
             character.Client = worldClientMock.Object;
 
             var armorItem = new Item(databasePreloader.Object, JustiaArmor.Type, JustiaArmor.TypeId)


### PR DESCRIPTION
Implemented notice including gm commands. 
`/bnotice` is missing until we find out the right parameters for it.

When executing notice commands, the only one that can fail and should return a failure message to the client is the `PlayerNotice` command (`/wnotice`), that's why I decided to create the `TrySendPlayerNotice` that returns a bool indicating whether the provided player is online and can receive the notice. The rest of the methods are simply voids.
Something I noticed is that on EP4, when this notice fails, the client receives a failing message that's triggered by the usual `GMCommandError packet`, but when sending that same packet indicating the error for notices, nothing is displayed in the client and after several attempts I couldn't figure it out, it may have to do with the EP difference but it shouldn't be the case.

Another thing that isn't part of this PR but is left pending is the notice timers, I want to discuss with you @aosyatnik how to proceed before moving forward with this.