### PR TITLE
Experience gain from mobs and leveling logic

### DIFF
--- a/src/Imgeneus.Network/Packets/PacketType.cs
+++ b/src/Imgeneus.Network/Packets/PacketType.cs
@@ -14,6 +14,7 @@
         CHARACTER_ATTACK_MOVEMENT_SPEED = 0x051C, // 1308
         CHARACTER_SHAPE_UPDATE = 0x051D, // 1309
         CHARACTER_ATTRIBUTE_SET = 0xF701, // 63233
+        CHARACTER_MAX_HP_MP_SP = 0x051F, // 1311
 
         // Common
         LOGOUT = 0x0107, // 263
@@ -259,5 +260,10 @@
         DYE_CONFIRM = 0x055B, // 1371
         DYE_REROLL = 0x055C, // 1372
         DYE_SELECT_ITEM = 0x055D, // 1373
+
+        // Experience and Leveling
+        EXPERIENCE_GAIN = 0x0207, // 519
+        CHARACTER_LEVEL_UP = 0x0508, // 1288
+        GM_CHARACTER_LEVEL_UP = 0x051E // 1310
     }
 }

--- a/src/Imgeneus.World/Game/BaseKillable.cs
+++ b/src/Imgeneus.World/Game/BaseKillable.cs
@@ -52,7 +52,7 @@ namespace Imgeneus.World.Game
         }
 
         /// <inheritdoc />
-        public ushort Level { get; protected set; }
+        public ushort Level { get; protected set; } = 1;
 
         #region Map
 

--- a/src/Imgeneus.World/Game/Monster/Mob.cs
+++ b/src/Imgeneus.World/Game/Monster/Mob.cs
@@ -26,6 +26,7 @@ namespace Imgeneus.World.Game.Monster
             Id = map.GenerateId();
             CurrentHP = _dbMob.HP;
             Level = _dbMob.Level;
+            Exp = _dbMob.Exp;
             AI = _dbMob.AI;
             ShouldRebirth = shouldRebirth;
 
@@ -60,6 +61,11 @@ namespace Imgeneus.World.Game.Monster
         /// Indicator, that shows if mob should rebirth after its' death.
         /// </summary>
         public bool ShouldRebirth { get; }
+
+        /// <summary>
+        /// Experience gained by a player who kills a mob.
+        /// </summary>
+        public short Exp { get; }
 
         #region Totel stats
 

--- a/src/Imgeneus.World/Game/Player/CharacterConfiguration.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Imgeneus.Core.Helpers;
+﻿using System.Linq;
+using Imgeneus.Core.Helpers;
 using Imgeneus.Database.Entities;
 using Newtonsoft.Json;
 
@@ -24,6 +25,16 @@ namespace Imgeneus.World.Game.Player
         public DefaultStat[] DefaultStats { get; set; }
 
         /// <summary>
+        /// Default maximum level for each mode
+        /// </summary>
+        public DefaultMaxLevel[] DefaultMaxLevels { get; set; }
+
+        /// <summary>
+        /// Default stat and skill points received per level
+        /// </summary>
+        public DefaultLevelStatSkillPoints[] DefaultLevelStatSkillPoints { get; set; }
+
+        /// <summary>
         /// Gets hp, mp, sp config by index calculation.
         /// </summary>
         public Character_HP_SP_MP GetConfig(int index)
@@ -37,6 +48,10 @@ namespace Imgeneus.World.Game.Player
                 return Configs[Configs.Length - 1];
             }
         }
+
+        public DefaultMaxLevel GetMaxLevelConfig(Mode mode) => DefaultMaxLevels.FirstOrDefault(dml => dml.Mode == mode);
+
+        public DefaultLevelStatSkillPoints GetLevelStatSkillPoints(Mode mode) => DefaultLevelStatSkillPoints.FirstOrDefault(dsp => dsp.Mode == mode);
     }
 
     public interface ICharacterConfiguration
@@ -51,7 +66,21 @@ namespace Imgeneus.World.Game.Player
         /// </summary>
         public DefaultStat[] DefaultStats { get; set; }
 
+        /// <summary>
+        /// Default maximum level for each mode
+        /// </summary>
+        public DefaultMaxLevel[] DefaultMaxLevels { get; set; }
+
+        /// <summary>
+        /// Default stat and skill points received per level
+        /// </summary>
+        public DefaultLevelStatSkillPoints[] DefaultLevelStatSkillPoints { get; set; }
+
         public Character_HP_SP_MP GetConfig(int index);
+
+        public DefaultMaxLevel GetMaxLevelConfig(Mode mode);
+
+        public DefaultLevelStatSkillPoints GetLevelStatSkillPoints(Mode mode);
     }
 
     public sealed class Character_HP_SP_MP

--- a/src/Imgeneus.World/Game/Player/CharacterLeveling.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterLeveling.cs
@@ -1,4 +1,5 @@
-﻿using Imgeneus.Database.Entities;
+﻿using System;
+using System.Linq;
 using Imgeneus.DatabaseBackgroundService.Handlers;
 using Imgeneus.Network.Packets.Game;
 
@@ -7,7 +8,25 @@ namespace Imgeneus.World.Game.Player
     public partial class Character
     {
         /// <summary>
-        /// Sets character new level.
+        /// Minimum experience needed for current player's level
+        /// </summary>
+        public uint MinLevelExp => Level > 1 ? _databasePreloader.Levels[(Mode, (ushort) (Level - 1))].Exp : 0;
+
+        /// <summary>
+        /// Experience needed to level up to next level
+        /// </summary>
+        public uint NextLevelExp => _databasePreloader.Levels[(Mode, Level)].Exp;
+
+        /// <summary>
+        /// Event that's fired when a player level's up
+        /// </summary>
+        public event Action<Character> OnLevelUp;
+
+        // Event that's fired when an admin set's a player's level
+        public event Action<Character> OnAdminLevelUp;
+
+        /// <summary>
+        /// Sets character's new level.
         /// </summary>
         private void SetLevel(ushort newLevel)
         {
@@ -19,10 +38,9 @@ namespace Imgeneus.World.Game.Player
         /// <summary>
         /// Attempts to set a new level for a character
         /// </summary>
-        /// <param name="newLevel"></param>
-        /// <returns>Success status</returns>
-        /// TODO: Update stats accordingly, send new stats to client
-        public bool TrySetLevel(ushort newLevel)
+        /// <param name="newLevel">New player level</param>
+        /// <returns>Success status indicating whether it's possible to set the new level or not.</returns>
+        private bool TrySetLevel(ushort newLevel)
         {
             if (Level == newLevel)
                 return false;
@@ -32,23 +50,168 @@ namespace Imgeneus.World.Game.Player
                 return false;
 
             // Check maximum level boundary
-            switch (Mode)
+            var maxLevel = _characterConfig.GetMaxLevelConfig(Mode).Level;
+
+            if (newLevel > maxLevel) return false;
+
+            SetLevel(newLevel);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to set a new level for a character and handles the levelling logic (exp, stat points, skill points, etc)
+        /// </summary>
+        /// <param name="newLevel">New player level</param>
+        /// <param name="changedByAdmin">Indicates whether the level change was issued by an admin or not.</param>
+        /// <returns>Success status indicating whether it's possible to set the new level or not.</returns>
+        public bool TryChangeLevel(ushort newLevel, bool changedByAdmin = false)
+        {
+            var previousLevel = Level;
+
+            if (!TrySetLevel(newLevel))
+                return false;
+
+            if (changedByAdmin)
             {
-                // TODO: Find out the maximum level for different modes
-                case Mode.Beginner:
-                case Mode.Normal:
-                case Mode.Hard:
-                case Mode.Ultimate:
-                    // TODO: Validate with maximum level permitted instead of hard coded value
-                    if (newLevel > 80) return false;
-                    else
-                    {
-                        SetLevel(newLevel);
-                        return true;
-                    }
-                default:
-                    return false;
+                // Change player experience to 0% of current level
+                SetExperience(MinLevelExp);
+
+                // Send player experience
+                SendAttribute(CharacterAttributeEnum.Exp);
+
+                OnAdminLevelUp?.Invoke(this);
             }
+            else
+            {
+                // Increase stats and skill points
+                var levelStats = _characterConfig.GetLevelStatSkillPoints(Mode);
+                IncreaseStatPoint(levelStats.StatPoint);
+                IncreaseSkillPoint(levelStats.SkillPoint);
+
+                OnLevelUp?.Invoke(this);
+            }
+
+            // Send max hp mp and sp
+            OnMax_HP_MP_SP_Changed?.Invoke(this);
+
+            // Recover
+            FullRecover();
+
+            // Update primary attribute
+            if (changedByAdmin)
+            {
+                var levelDifference = newLevel - previousLevel;
+
+                if (levelDifference > 0)
+                    IncrementPrimaryAttribute((ushort) levelDifference);
+                else
+                    DecreasePrimaryAttribute((ushort) Math.Abs(levelDifference));
+            }
+            else
+            {
+                IncrementPrimaryAttribute(1);
+            }
+
+            // Send primary attribute
+            SendAttribute(GetPrimaryAttribute());
+
+            // Send new level
+            SendAttribute(CharacterAttributeEnum.Level);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Sets character's experience.
+        /// </summary>
+        private void SetExperience(uint exp)
+        {
+            Exp = exp;
+
+            _taskQueue.Enqueue(ActionType.SAVE_CHARACTER_EXPERIENCE, Id, Exp);
+        }
+
+        /// <summary>
+        /// Attempts to set the experience of a player and updates the player's level if necessary.
+        /// </summary>
+        /// <param name="exp">New player experience</param>
+        /// <param name="changedByAdmin">Indicates whether the level change was issued by an admin or not.</param>
+        /// <returns>Success status indicating whether it's possible to set the new level or not.</returns>
+        public bool TryChangeExperience(uint exp, bool changedByAdmin = false)
+        {
+            if (!CanSetExperience(exp)) return false;
+
+            SetExperience(exp);
+
+            SendAttribute(CharacterAttributeEnum.Exp);
+
+            var currentLevelExp = _databasePreloader.Levels[(Mode, Level)].Exp;
+
+            uint lowerLevelExp = 0;
+
+            if (Level > 1)
+            {
+                lowerLevelExp = _databasePreloader.Levels[(Mode, (ushort) (Level - 1))].Exp;
+            }
+
+            if (Exp >= currentLevelExp || Exp < lowerLevelExp)
+            {
+                TryChangeLevel(GetLevelByExperience(Exp), changedByAdmin);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to add experience to a player.
+        /// </summary>
+        /// <param name="expAmount"></param>
+        /// <returns></returns>
+        public bool TryAddExperience(ushort expAmount)
+        {
+            var newExp = Exp + expAmount;
+
+            if (!CanSetExperience(newExp)) return false;
+
+            SetExperience(newExp);
+
+            SendExperienceGain(expAmount);
+
+            if (Exp >= NextLevelExp)
+            {
+                TryChangeLevel(GetLevelByExperience(Exp));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if an experience value can be set, verifying it doesn't exceed the max level's experience
+        /// </summary>
+        /// <param name="exp"></param>
+        /// <returns>Success status indicating whether it is possible to set an experience value or not.</returns>
+        private bool CanSetExperience(uint exp)
+        {
+            var maxLevel = _characterConfig.GetMaxLevelConfig(Mode).Level;
+
+            var maxLevelInfo = _databasePreloader.Levels[(Mode, maxLevel)];
+
+            // Exp can't be superior than max level's experience
+            return exp <= maxLevelInfo.Exp;
+        }
+
+        /// <summary>
+        /// Helper method that calculates the level that corresponds to a certain experience value.
+        /// </summary>
+        private ushort GetLevelByExperience(uint exp)
+        {
+            var levelInfo = _databasePreloader.Levels.Values
+                .Where(l => l.Exp > exp)
+                .OrderBy(l => l.Level)
+                .First();
+
+            return levelInfo.Level;
         }
     }
 }

--- a/src/Imgeneus.World/Game/Player/CharacterLeveling.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterLeveling.cs
@@ -104,17 +104,17 @@ namespace Imgeneus.World.Game.Player
                 var levelDifference = newLevel - previousLevel;
 
                 if (levelDifference > 0)
-                    IncrementPrimaryAttribute((ushort) levelDifference);
+                    IncreasePrimaryStat((ushort) levelDifference);
                 else
-                    DecreasePrimaryAttribute((ushort) Math.Abs(levelDifference));
+                    DecreasePrimaryStat((ushort) Math.Abs(levelDifference));
             }
             else
             {
-                IncrementPrimaryAttribute(1);
+                IncreasePrimaryStat(1);
             }
 
             // Send primary attribute
-            SendAttribute(GetPrimaryAttribute());
+            SendAttribute(GetAttributeByStat(GetPrimaryStat()));
 
             // Send new level
             SendAttribute(CharacterAttributeEnum.Level);

--- a/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
@@ -484,7 +484,7 @@ namespace Imgeneus.World.Game.Player
                     break;
 
                 case CharacterAttributeEnum.Level:
-                    if (targetPlayer.TrySetLevel((ushort)attributeValue))
+                    if (targetPlayer.TryChangeLevel((ushort)attributeValue, true))
                         SetAttributeAndSendCommandSuccess();
                     else
                         SendCommandError();
@@ -523,10 +523,12 @@ namespace Imgeneus.World.Game.Player
                     SendCommandError();
                     return;
 
-                // TODO: Add experience logic
                 case CharacterAttributeEnum.Exp:
-                    SendCommandError();
-                    return;
+                    if (targetPlayer.TryChangeExperience((ushort)attributeValue, true))
+                        SetAttributeAndSendCommandSuccess();
+                    else
+                        SendCommandError();
+                    break;
 
                 case CharacterAttributeEnum.Kills:
                     targetPlayer.SetKills((ushort)attributeValue);

--- a/src/Imgeneus.World/Game/Player/CharacterPacketSenders.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketSenders.cs
@@ -118,5 +118,7 @@ namespace Imgeneus.World.Game.Player
 
         public void SendAttribute(CharacterAttributeEnum attribute) =>
             _packetsHelper.SendAttribute(Client, attribute, GetAttributeValue(attribute));
+
+        public void SendExperienceGain(ushort expAmount) => _packetsHelper.SendExperienceGain(Client, expAmount);
     }
 }

--- a/src/Imgeneus.World/Game/Player/CharacterStatEnum.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterStatEnum.cs
@@ -1,0 +1,12 @@
+namespace Imgeneus.World.Game.Player
+{
+    public enum CharacterStatEnum
+    {
+        Strength = 0,
+        Dexterity = 1,
+        Reaction = 2,
+        Intelligence = 3,
+        Luck = 4,
+        Wisdom = 5
+    }
+}

--- a/src/Imgeneus.World/Game/Player/CharacterStats.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterStats.cs
@@ -16,7 +16,7 @@ namespace Imgeneus.World.Game.Player
         public ushort MapId { get; private set; }
         public Race Race { get; set; }
         public CharacterProfession Class { get; set; }
-        public Mode Mode { get; private set; }
+        public Mode Mode { get; private set; } = Mode.Beginner;
         public byte Hair { get; set; }
         public byte Face { get; set; }
         public byte Height { get; set; }
@@ -70,6 +70,11 @@ namespace Imgeneus.World.Game.Player
         #endregion
 
         #region Max HP & SP & MP
+
+        /// <summary>
+        /// Event that's fired when max hp, mp and sp change.
+        /// </summary>
+        public event Action<Character> OnMax_HP_MP_SP_Changed;
 
         private void Character_OnMaxHPChanged(IKillable sender, int maxHP)
         {
@@ -155,6 +160,104 @@ namespace Imgeneus.World.Game.Player
             get
             {
                 return ConstSP + ExtraSP;
+            }
+        }
+
+        public CharacterAttributeEnum GetPrimaryAttribute()
+        {
+            var defaultStat = _characterConfig.DefaultStats.First(s => s.Job == Class);
+
+            switch (defaultStat.MainStat)
+            {
+                case 0:
+                    return CharacterAttributeEnum.Strength;
+
+                case 1:
+                    return CharacterAttributeEnum.Dexterity;
+
+                case 2:
+                    return CharacterAttributeEnum.Reaction;
+                case 3:
+                    return CharacterAttributeEnum.Intelligence;
+
+                case 4:
+                    return CharacterAttributeEnum.Wisdom;
+
+                case 5:
+                    return CharacterAttributeEnum.Luck;
+
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        public void IncrementPrimaryAttribute(ushort amount = 1)
+        {
+            var defaultStat = _characterConfig.DefaultStats.First(s => s.Job == Class);
+
+            switch (defaultStat.MainStat)
+            {
+                case 0:
+                    Strength += amount;
+                    break;
+
+                case 1:
+                    Dexterity += amount;
+                    break;
+
+                case 2:
+                    Reaction += amount;
+                    break;
+
+                case 3:
+                    Intelligence += amount;
+                    break;
+
+                case 4:
+                    Wisdom += amount;
+                    break;
+
+                case 5:
+                    Luck += amount;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        public void DecreasePrimaryAttribute(ushort amount = 1)
+        {
+            var defaultStat = _characterConfig.DefaultStats.First(s => s.Job == Class);
+
+            switch (defaultStat.MainStat)
+            {
+                case 0:
+                    Strength -= amount;
+                    break;
+
+                case 1:
+                    Dexterity -= amount;
+                    break;
+
+                case 2:
+                    Reaction -= amount;
+                    break;
+
+                case 3:
+                    Intelligence -= amount;
+                    break;
+
+                case 4:
+                    Wisdom -= amount;
+                    break;
+
+                case 5:
+                    Luck -= amount;
+                    break;
+
+                default:
+                    break;
             }
         }
 
@@ -673,6 +776,12 @@ namespace Imgeneus.World.Game.Player
         }
 
         /// <summary>
+        /// Increases the player's stat points by a certain amount
+        /// </summary>
+        /// <param name="amount"></param>
+        public void IncreaseStatPoint(ushort amount) => SetStatPoint(StatPoint += amount);
+
+        /// <summary>
         /// Set the skill points amount
         /// </summary>
         public void SetSkillPoint(ushort skillPoint)
@@ -681,6 +790,12 @@ namespace Imgeneus.World.Game.Player
 
             _taskQueue.Enqueue(ActionType.SAVE_CHARACTER_SKILLPOINT, Id, SkillPoint);
         }
+
+        /// <summary>
+        /// Increases the player's skill points by a certain amount
+        /// </summary>
+        /// <param name="amount"></param>
+        public void IncreaseSkillPoint(ushort amount) => SetSkillPoint(StatPoint += amount);
 
         #endregion
 

--- a/src/Imgeneus.World/Game/Player/CharacterStats.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterStats.cs
@@ -163,27 +163,61 @@ namespace Imgeneus.World.Game.Player
             }
         }
 
-        public CharacterAttributeEnum GetPrimaryAttribute()
+        /// <summary>
+        /// Gets the character's primary stat
+        /// </summary>
+        public CharacterStatEnum GetPrimaryStat()
         {
             var defaultStat = _characterConfig.DefaultStats.First(s => s.Job == Class);
 
             switch (defaultStat.MainStat)
             {
                 case 0:
-                    return CharacterAttributeEnum.Strength;
+                    return CharacterStatEnum.Strength;
 
                 case 1:
-                    return CharacterAttributeEnum.Dexterity;
+                    return CharacterStatEnum.Dexterity;
 
                 case 2:
-                    return CharacterAttributeEnum.Reaction;
+                    return CharacterStatEnum.Reaction;
+
                 case 3:
-                    return CharacterAttributeEnum.Intelligence;
+                    return CharacterStatEnum.Intelligence;
 
                 case 4:
-                    return CharacterAttributeEnum.Wisdom;
+                    return CharacterStatEnum.Wisdom;
 
                 case 5:
+                    return CharacterStatEnum.Luck;
+
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Gets the character's primary stat
+        /// </summary>
+        public CharacterAttributeEnum GetAttributeByStat(CharacterStatEnum stat)
+        {
+            switch (stat)
+            {
+                case CharacterStatEnum.Strength:
+                    return CharacterAttributeEnum.Strength;
+
+                case CharacterStatEnum.Dexterity:
+                    return CharacterAttributeEnum.Dexterity;
+
+                case CharacterStatEnum.Reaction:
+                    return CharacterAttributeEnum.Reaction;
+
+                case CharacterStatEnum.Intelligence:
+                    return CharacterAttributeEnum.Intelligence;
+
+                case CharacterStatEnum.Wisdom:
+                    return CharacterAttributeEnum.Wisdom;
+
+                case CharacterStatEnum.Luck:
                     return CharacterAttributeEnum.Luck;
 
                 default:
@@ -191,33 +225,37 @@ namespace Imgeneus.World.Game.Player
             }
         }
 
-        public void IncrementPrimaryAttribute(ushort amount = 1)
+        /// <summary>
+        /// Increases a character's main stat by a certain amount
+        /// </summary>
+        /// <param name="amount">Decrease amount</param>
+        public void IncreasePrimaryStat(ushort amount = 1)
         {
-            var defaultStat = _characterConfig.DefaultStats.First(s => s.Job == Class);
+            var primaryAttribute = GetPrimaryStat();
 
-            switch (defaultStat.MainStat)
+            switch (primaryAttribute)
             {
-                case 0:
+                case CharacterStatEnum.Strength:
                     Strength += amount;
                     break;
 
-                case 1:
+                case CharacterStatEnum.Dexterity:
                     Dexterity += amount;
                     break;
 
-                case 2:
+                case CharacterStatEnum.Reaction:
                     Reaction += amount;
                     break;
 
-                case 3:
+                case CharacterStatEnum.Intelligence:
                     Intelligence += amount;
                     break;
 
-                case 4:
+                case CharacterStatEnum.Wisdom:
                     Wisdom += amount;
                     break;
 
-                case 5:
+                case CharacterStatEnum.Luck:
                     Luck += amount;
                     break;
 
@@ -226,33 +264,37 @@ namespace Imgeneus.World.Game.Player
             }
         }
 
-        public void DecreasePrimaryAttribute(ushort amount = 1)
+        /// <summary>
+        /// Decreases a character's main stat by a certain amount
+        /// </summary>
+        /// <param name="amount">Decrease amount</param>
+        public void DecreasePrimaryStat(ushort amount = 1)
         {
-            var defaultStat = _characterConfig.DefaultStats.First(s => s.Job == Class);
+            var primaryAttribute = GetPrimaryStat();
 
-            switch (defaultStat.MainStat)
+            switch (primaryAttribute)
             {
-                case 0:
+                case CharacterStatEnum.Strength:
                     Strength -= amount;
                     break;
 
-                case 1:
+                case CharacterStatEnum.Dexterity:
                     Dexterity -= amount;
                     break;
 
-                case 2:
+                case CharacterStatEnum.Reaction:
                     Reaction -= amount;
                     break;
 
-                case 3:
+                case CharacterStatEnum.Intelligence:
                     Intelligence -= amount;
                     break;
 
-                case 4:
+                case CharacterStatEnum.Wisdom:
                     Wisdom -= amount;
                     break;
 
-                case 5:
+                case CharacterStatEnum.Luck:
                     Luck -= amount;
                     break;
 
@@ -570,61 +612,11 @@ namespace Imgeneus.World.Game.Player
             Wisdom = defaultStat.Wis;
             Luck = defaultStat.Luc;
 
-            ushort statPerLevel;
-            switch (Mode)
-            {
-                case Mode.Beginner:
-                    statPerLevel = 3;
-                    break;
+            var statPerLevel = _characterConfig.GetLevelStatSkillPoints(Mode).StatPoint;
 
-                case Mode.Normal:
-                    statPerLevel = 5;
-                    break;
+            SetStatPoint((ushort)((Level - 1) * statPerLevel)); // Level - 1, because we are starting with 1 level.
 
-                case Mode.Hard:
-                    statPerLevel = 7;
-                    break;
-
-                case Mode.Ultimate:
-                    statPerLevel = 9;
-                    break;
-
-                default:
-                    statPerLevel = 0;
-                    break;
-            }
-
-            StatPoint = (ushort)((Level - 1) * statPerLevel); // Level - 1, because we are starting with 1 level.
-
-            switch (defaultStat.MainStat)
-            {
-                case 0:
-                    Strength += (ushort)(Level - 1);
-                    break;
-
-                case 1:
-                    Dexterity += (ushort)(Level - 1);
-                    break;
-
-                case 2:
-                    Reaction += (ushort)(Level - 1);
-                    break;
-
-                case 3:
-                    Intelligence += (ushort)(Level - 1);
-                    break;
-
-                case 4:
-                    Wisdom += (ushort)(Level - 1);
-                    break;
-
-                case 5:
-                    Luck += (ushort)(Level - 1);
-                    break;
-
-                default:
-                    break;
-            }
+            IncreasePrimaryStat((ushort)(Level - 1));
 
             _taskQueue.Enqueue(ActionType.UPDATE_STATS, Id, Strength, Dexterity, Reaction, Intelligence, Wisdom, Luck, StatPoint);
             _packetsHelper.SendResetStats(Client, this);

--- a/src/Imgeneus.World/Game/Player/DefaultLevelStatSkillPoints.cs
+++ b/src/Imgeneus.World/Game/Player/DefaultLevelStatSkillPoints.cs
@@ -5,7 +5,7 @@ namespace Imgeneus.World.Game.Player
     public class DefaultLevelStatSkillPoints
     {
         public Mode Mode { get; set; }
-        public byte StatPoint { get; set; }
-        public byte SkillPoint { get; set; }
+        public ushort StatPoint { get; set; }
+        public ushort SkillPoint { get; set; }
     }
 }

--- a/src/Imgeneus.World/Game/Player/DefaultLevelStatSkillPoints.cs
+++ b/src/Imgeneus.World/Game/Player/DefaultLevelStatSkillPoints.cs
@@ -1,0 +1,11 @@
+using Imgeneus.Database.Entities;
+
+namespace Imgeneus.World.Game.Player
+{
+    public class DefaultLevelStatSkillPoints
+    {
+        public Mode Mode { get; set; }
+        public byte StatPoint { get; set; }
+        public byte SkillPoint { get; set; }
+    }
+}

--- a/src/Imgeneus.World/Game/Player/DefaultMaxLevel.cs
+++ b/src/Imgeneus.World/Game/Player/DefaultMaxLevel.cs
@@ -1,0 +1,10 @@
+using Imgeneus.Database.Entities;
+
+namespace Imgeneus.World.Game.Player
+{
+    public class DefaultMaxLevel
+    {
+        public Mode Mode { get; set; }
+        public ushort Level { get; set; }
+    }
+}

--- a/src/Imgeneus.World/Game/Zone/MapCell.cs
+++ b/src/Imgeneus.World/Game/Zone/MapCell.cs
@@ -231,8 +231,9 @@ namespace Imgeneus.World.Game.Zone
             character.OnSkillCastStarted -= Character_OnSkillCastStarted;
             character.OnUsedItem -= Character_OnUsedItem;
             character.OnMaxHPChanged -= Character_OnMaxHPChanged;
+            character.OnMax_HP_MP_SP_Changed -= Character_OnMax_HP_SP_MP_Changed;
             character.OnRecover -= Character_OnRecover;
-            character.OnFullRecover += Character_OnFullRecover;
+            character.OnFullRecover -= Character_OnFullRecover;
             character.OnSkillKeep -= Character_OnSkillKeep;
             character.OnShapeChange -= Character_OnShapeChange;
             character.OnUsedRangeSkill -= Character_OnUsedRangeSkill;

--- a/src/Imgeneus.World/Game/Zone/MapCell.cs
+++ b/src/Imgeneus.World/Game/Zone/MapCell.cs
@@ -202,13 +202,17 @@ namespace Imgeneus.World.Game.Zone
             character.OnSkillCastStarted += Character_OnSkillCastStarted;
             character.OnUsedItem += Character_OnUsedItem;
             character.OnMaxHPChanged += Character_OnMaxHPChanged;
+            character.OnMax_HP_MP_SP_Changed += Character_OnMax_HP_SP_MP_Changed;
             character.OnRecover += Character_OnRecover;
+            character.OnFullRecover += Character_OnFullRecover;
             character.OnSkillKeep += Character_OnSkillKeep;
             character.OnShapeChange += Character_OnShapeChange;
             character.OnUsedRangeSkill += Character_OnUsedRangeSkill;
             character.OnRebirthed += Character_OnRebirthed;
             character.OnAppearanceChanged += Character_OnAppearanceChanged;
             character.OnStartSummonVehicle += Character_OnStartSummonVehicle;
+            character.OnLevelUp += Character_OnLevelUp;
+            character.OnAdminLevelUp += Character_OnAdminLevelUp;
         }
 
         /// <summary>
@@ -228,12 +232,15 @@ namespace Imgeneus.World.Game.Zone
             character.OnUsedItem -= Character_OnUsedItem;
             character.OnMaxHPChanged -= Character_OnMaxHPChanged;
             character.OnRecover -= Character_OnRecover;
+            character.OnFullRecover += Character_OnFullRecover;
             character.OnSkillKeep -= Character_OnSkillKeep;
             character.OnShapeChange -= Character_OnShapeChange;
             character.OnUsedRangeSkill -= Character_OnUsedRangeSkill;
             character.OnRebirthed -= Character_OnRebirthed;
             character.OnAppearanceChanged -= Character_OnAppearanceChanged;
             character.OnStartSummonVehicle -= Character_OnStartSummonVehicle;
+            character.OnLevelUp -= Character_OnLevelUp;
+            character.OnAdminLevelUp -= Character_OnAdminLevelUp;
         }
 
         #region Character listeners
@@ -347,10 +354,25 @@ namespace Imgeneus.World.Game.Zone
                 _packetsHelper.SendRecoverCharacter(player.Client, sender, hp, mp, sp);
         }
 
+        private void Character_OnFullRecover(IKillable sender)
+        {
+            foreach (var player in GetAllPlayers(true))
+                _packetsHelper.SendRecoverCharacter(player.Client, sender, sender.CurrentHP, sender.CurrentMP, sender.CurrentSP);
+        }
+
         private void Character_OnMaxHPChanged(IKillable sender, int maxHP)
         {
             foreach (var player in GetAllPlayers(true))
                 _packetsHelper.Send_Max_HP(player.Client, sender.Id, maxHP);
+        }
+
+        /// <summary>
+        /// Notifies other players that player's max HP, MP and SP changed
+        /// </summary>
+        private void Character_OnMax_HP_SP_MP_Changed(Character sender)
+        {
+            foreach (var player in GetAllPlayers(true))
+                _packetsHelper.SendMax_HP_MP_SP(player.Client, sender);
         }
 
         private void Character_OnSkillKeep(IKillable sender, ActiveBuff buff, AttackResult result)
@@ -391,6 +413,24 @@ namespace Imgeneus.World.Game.Zone
         {
             foreach (var player in GetAllPlayers(true))
                 _packetsHelper.SendStartSummoningVehicle(player.Client, sender);
+        }
+
+        /// <summary>
+        /// Notifies other players that player levelled up
+        /// </summary>
+        private void Character_OnLevelUp(Character sender)
+        {
+            foreach (var player in GetAllPlayers(true))
+                _packetsHelper.SendLevelUp(player.Client, sender);
+        }
+
+        /// <summary>
+        /// Notifies other players that an admin levelled up a player
+        /// </summary>
+        private void Character_OnAdminLevelUp(Character sender)
+        {
+            foreach (var player in GetAllPlayers(true))
+                _packetsHelper.SendLevelUp(player.Client, sender, true);
         }
 
         #endregion
@@ -497,6 +537,10 @@ namespace Imgeneus.World.Game.Zone
 
             foreach (var player in GetAllPlayers(true))
                 _packetsHelper.SendMobDead(player.Client, sender, killer);
+
+            // Add experience to killer
+            if (killer is Character killerCharacter)
+                killerCharacter.TryAddExperience((ushort)mob.Exp);
         }
 
         private void Mob_OnMove(Mob sender)

--- a/src/Imgeneus.World/Packets/PacketsHelper.cs
+++ b/src/Imgeneus.World/Packets/PacketsHelper.cs
@@ -736,7 +736,7 @@ namespace Imgeneus.World.Packets
             using var packet = new Packet(PacketType.ITEM_COMPOSE_ABSOLUTE);
             packet.Write(isFailure);
             packet.Write(new CraftName(craftName).Serialize());
-            packet.Write(true); // ? 
+            packet.Write(true); // ?
 
             client.SendPacket(packet);
         }
@@ -1107,8 +1107,29 @@ namespace Imgeneus.World.Packets
         internal void SendAttribute(IWorldClient client, CharacterAttributeEnum attribute, uint attributeValue)
         {
             using var packet = new Packet(PacketType.CHARACTER_ATTRIBUTE_SET);
-            packet.Write((byte)attribute);
-            packet.Write(attributeValue);
+            packet.Write(new CharacterAttribute(attribute, attributeValue).Serialize());
+            client.SendPacket(packet);
+        }
+
+        internal void SendExperienceGain(IWorldClient client, uint exp)
+        {
+            using var packet = new Packet(PacketType.EXPERIENCE_GAIN);
+            packet.Write(new CharacterExperienceGain(exp).Serialize());
+            client.SendPacket(packet);
+        }
+
+        internal void SendMax_HP_MP_SP(IWorldClient client, Character character)
+        {
+            using var packet = new Packet(PacketType.CHARACTER_MAX_HP_MP_SP);
+            packet.Write(new CharacterMax_HP_MP_SP(character));
+            client.SendPacket(packet);
+        }
+
+        internal void SendLevelUp(IWorldClient client, Character character, bool isAdminLevelUp = false)
+        {
+            var type = isAdminLevelUp ? PacketType.GM_CHARACTER_LEVEL_UP : PacketType.CHARACTER_LEVEL_UP;
+            using var packet = new Packet(type);
+            packet.Write(new CharacterLevelUp(character).Serialize());
             client.SendPacket(packet);
         }
     }

--- a/src/Imgeneus.World/Serialization/CharacterAttribute.cs
+++ b/src/Imgeneus.World/Serialization/CharacterAttribute.cs
@@ -1,0 +1,20 @@
+using BinarySerialization;
+using Imgeneus.Network.Packets.Game;
+using Imgeneus.Network.Serialization;
+
+namespace Imgeneus.World.Serialization
+{
+    public class CharacterAttribute : BaseSerializable
+    {
+        [FieldOrder(0)]
+        public byte Attribute { get; }
+        [FieldOrder(1)]
+        public uint Value { get; }
+
+        public CharacterAttribute(CharacterAttributeEnum attribute, uint value)
+        {
+            Attribute = (byte)attribute;
+            Value = attribute == CharacterAttributeEnum.Exp ? value / 10 : value; // Normalize experience for ep8 game
+        }
+    }
+}

--- a/src/Imgeneus.World/Serialization/CharacterDetails.cs
+++ b/src/Imgeneus.World/Serialization/CharacterDetails.cs
@@ -42,13 +42,13 @@ namespace Imgeneus.Network.Serialization
         public ushort Angle { get; }
 
         [FieldOrder(12)]
-        public uint StartLvlExp { get => 100; } // EXP Values are multiplied by 10
+        public uint StartLvlExp { get; }
 
         [FieldOrder(13)]
-        public uint EndLvlExp { get => 250; } // Next EXP is at 2500. Client takes the previous value, calculates the difference = 1500
+        public uint EndLvlExp { get; }
 
         [FieldOrder(14)]
-        public uint CurrentExp { get => 120; } //_character.Exp; } Current EXP is at 1200
+        public uint CurrentExp { get; }
 
         [FieldOrder(15)]
         public uint Gold { get; }
@@ -88,6 +88,9 @@ namespace Imgeneus.Network.Serialization
             StatPoint = character.StatPoint;
             SkillPoint = character.SkillPoint;
             Angle = character.Angle;
+            StartLvlExp = character.MinLevelExp / 10; // Normalize experience for ep8 game
+            EndLvlExp = character.NextLevelExp / 10; // Normalize experience for ep8 game
+            CurrentExp = character.Exp / 10; // Normalize experience for ep8 game
             Gold = character.Gold;
             PosX = character.PosX;
             PosY = character.PosY;

--- a/src/Imgeneus.World/Serialization/CharacterExperienceGain.cs
+++ b/src/Imgeneus.World/Serialization/CharacterExperienceGain.cs
@@ -1,0 +1,16 @@
+using BinarySerialization;
+using Imgeneus.Network.Serialization;
+
+namespace Imgeneus.World.Serialization
+{
+    public class CharacterExperienceGain : BaseSerializable
+    {
+        [FieldOrder(0)]
+        public uint Exp { get; }
+
+        public CharacterExperienceGain(uint exp)
+        {
+            Exp = exp / 10; // Normalize experience gain for ep8 game
+        }
+    }
+}

--- a/src/Imgeneus.World/Serialization/CharacterLevelUp.cs
+++ b/src/Imgeneus.World/Serialization/CharacterLevelUp.cs
@@ -1,0 +1,32 @@
+using BinarySerialization;
+using Imgeneus.Network.Serialization;
+using Imgeneus.World.Game.Player;
+
+namespace Imgeneus.World.Serialization
+{
+    public class CharacterLevelUp : BaseSerializable
+    {
+        [FieldOrder(0)]
+        public int CharacterId { get; }
+        [FieldOrder(1)]
+        public ushort Level { get; }
+        [FieldOrder(2)]
+        public ushort StatPoint { get; }
+        [FieldOrder(3)]
+        public ushort SkillPoint { get; }
+        [FieldOrder(4)]
+        public uint MinLevelExp { get; }
+        [FieldOrder(5)]
+        public uint NextLevelExp { get; }
+
+        public CharacterLevelUp(Character character)
+        {
+            CharacterId = character.Id;
+            Level = character.Level;
+            StatPoint = character.StatPoint;
+            SkillPoint = character.SkillPoint;
+            MinLevelExp = character.MinLevelExp / 10; // Normalize experience for ep8 game
+            NextLevelExp = character.NextLevelExp / 10; // Normalize experience for ep8 game
+        }
+    }
+}

--- a/src/Imgeneus.World/Serialization/CharacterMax_HP_MP_SP.cs
+++ b/src/Imgeneus.World/Serialization/CharacterMax_HP_MP_SP.cs
@@ -1,0 +1,21 @@
+using Imgeneus.Network.Serialization;
+using Imgeneus.World.Game.Player;
+
+namespace Imgeneus.World.Serialization
+{
+    public class CharacterMax_HP_MP_SP : BaseSerializable
+    {
+        public int CharacterId { get; }
+        public int MaxHP { get; }
+        public int MaxMP { get; }
+        public int MaxSP { get; }
+
+        public CharacterMax_HP_MP_SP(Character character)
+        {
+            CharacterId = character.Id;
+            MaxHP = character.MaxHP;
+            MaxMP = character.MaxSP;
+            MaxSP = character.MaxSP;
+        }
+    }
+}

--- a/src/Imgeneus.World/config/character.json
+++ b/src/Imgeneus.World/config/character.json
@@ -2586,11 +2586,11 @@
   "DefaultMaxLevels": [
     {
       "Mode": 0,
-      "Level": 80
+      "Level": 30
     },
     {
       "Mode": 1,
-      "Level": 80
+      "Level": 30
     },
     {
       "Mode": 2,

--- a/src/Imgeneus.World/config/character.json
+++ b/src/Imgeneus.World/config/character.json
@@ -2613,12 +2613,12 @@
       "SkillPoint": 3
     },
     {
-      "Mode": 0,
+      "Mode": 2,
       "StatPoint": 7,
       "SkillPoint": 4
     },
     {
-      "Mode": 0,
+      "Mode": 3,
       "StatPoint": 9,
       "SkillPoint": 5
     }

--- a/src/Imgeneus.World/config/character.json
+++ b/src/Imgeneus.World/config/character.json
@@ -2582,5 +2582,45 @@
       "Luc": 9,
       "MainStat": 4
     }
+  ],
+  "DefaultMaxLevels": [
+    {
+      "Mode": 0,
+      "Level": 80
+    },
+    {
+      "Mode": 1,
+      "Level": 80
+    },
+    {
+      "Mode": 2,
+      "Level": 80
+    },
+    {
+      "Mode": 3,
+      "Level": 80
+    }
+  ],
+  "DefaultLevelStatSkillPoints": [
+    {
+      "Mode": 0,
+      "StatPoint": 5,
+      "SkillPoint": 3
+    },
+    {
+      "Mode": 1,
+      "StatPoint": 5,
+      "SkillPoint": 3
+    },
+    {
+      "Mode": 0,
+      "StatPoint": 7,
+      "SkillPoint": 4
+    },
+    {
+      "Mode": 0,
+      "StatPoint": 9,
+      "SkillPoint": 5
+    }
   ]
 }

--- a/src/UnitTests/Imgeneus.World.Tests/BaseTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/BaseTest.cs
@@ -50,6 +50,7 @@ namespace Imgeneus.World.Tests
         protected Character CreateCharacter(Map map = null)
         {
             var character = new Character(loggerMock.Object, gameWorldMock.Object, config.Object, taskQueuMock.Object, databasePreloader.Object, chatMock.Object, linkingMock.Object, dyeingMock.Object, mobFactoryMock.Object, npcFactoryMock.Object, noticeManagerMock.Object);
+
             character.Client = worldClientMock.Object;
 
             if (map != null)
@@ -77,6 +78,25 @@ namespace Imgeneus.World.Tests
                           MainStat = 0
                       }
                   });
+
+            config.Setup((conf) => conf.GetMaxLevelConfig(It.IsAny<Mode>()))
+                .Returns(
+                    new DefaultMaxLevel()
+                    {
+                        Mode = Mode.Ultimate,
+                        Level = 80
+                    }
+                );
+
+            config.Setup((conf) => conf.GetLevelStatSkillPoints(It.IsAny<Mode>()))
+                .Returns(
+                    new DefaultLevelStatSkillPoints()
+                    {
+                        Mode = Mode.Ultimate,
+                        StatPoint = 9,
+                        SkillPoint = 7
+                    }
+                );
 
             databasePreloader
                 .SetupGet((preloader) => preloader.Mobs)
@@ -123,6 +143,28 @@ namespace Imgeneus.World.Tests
             databasePreloader
                 .SetupGet((preloader) => preloader.MobItems)
                 .Returns(new Dictionary<(ushort MobId, byte ItemOrder), DbMobItems>());
+
+            databasePreloader
+                .SetupGet((preloader) => preloader.Levels)
+                .Returns(new Dictionary<(Mode mode, ushort level), DbLevel>()
+                {
+                    { (Mode.Beginner, 1), Level1_Mode1 },
+                    { (Mode.Normal, 1), Level1_Mode2 },
+                    { (Mode.Hard, 1), Level1_Mode3 },
+                    { (Mode.Ultimate, 1), Level1_Mode4 },
+                    { (Mode.Beginner, 2), Level2_Mode1 },
+                    { (Mode.Normal, 2), Level2_Mode2 },
+                    { (Mode.Hard, 2), Level2_Mode3 },
+                    { (Mode.Ultimate, 2), Level2_Mode4 },
+                    { (Mode.Beginner, 79), Level79_Mode1 },
+                    { (Mode.Normal, 79), Level79_Mode2 },
+                    { (Mode.Hard, 79), Level79_Mode3 },
+                    { (Mode.Ultimate, 79), Level79_Mode4 },
+                    { (Mode.Beginner, 80), Level80_Mode1 },
+                    { (Mode.Normal, 80), Level80_Mode2 },
+                    { (Mode.Hard, 80), Level80_Mode3 },
+                    { (Mode.Ultimate, 80), Level80_Mode4 },
+                });
         }
 
         #region Test mobs
@@ -136,7 +178,8 @@ namespace Imgeneus.World.Tests
             HP = 2765,
             Element = Element.Wind1,
             AttackSpecial3 = MobRespawnTime.TestEnv,
-            NormalTime = 1
+            NormalTime = 1,
+            Exp = 70
         };
 
         protected DbMob CrypticImmortal = new DbMob()
@@ -152,7 +195,8 @@ namespace Imgeneus.World.Tests
             AttackRange1 = 5,
             AttackTime1 = 2500,
             NormalTime = 1,
-            ChaseTime = 1
+            ChaseTime = 1,
+            Exp = 3253
         };
 
         #endregion
@@ -399,6 +443,122 @@ namespace Imgeneus.World.Tests
             ReqIg = 0, // always fail linking or extracting, unless hammer is used
             Count = 255,
             Quality = 0
+        };
+
+        #endregion
+
+        #region Levels
+
+        protected DbLevel Level1_Mode1 = new DbLevel()
+        {
+            Level = 1,
+            Mode = Mode.Beginner,
+            Exp = 70
+        };
+
+        protected DbLevel Level1_Mode2 = new DbLevel()
+        {
+            Level = 1,
+            Mode = Mode.Normal,
+            Exp = 200
+        };
+
+        protected DbLevel Level1_Mode3 = new DbLevel()
+        {
+            Level = 1,
+            Mode = Mode.Hard,
+            Exp = 200
+        };
+
+        protected DbLevel Level1_Mode4 = new DbLevel()
+        {
+            Level = 1,
+            Mode = Mode.Ultimate,
+            Exp = 200
+        };
+
+        protected DbLevel Level2_Mode1 = new DbLevel()
+        {
+            Level = 2,
+            Mode = Mode.Beginner,
+            Exp = 130
+        };
+
+        protected DbLevel Level2_Mode2 = new DbLevel()
+        {
+            Level = 2,
+            Mode = Mode.Normal,
+            Exp = 400
+        };
+
+        protected DbLevel Level2_Mode3 = new DbLevel()
+        {
+            Level = 2,
+            Mode = Mode.Hard,
+            Exp = 400
+        };
+
+        protected DbLevel Level2_Mode4 = new DbLevel()
+        {
+            Level = 2,
+            Mode = Mode.Ultimate,
+            Exp = 400
+        };
+
+        protected DbLevel Level79_Mode1 = new DbLevel()
+        {
+            Level = 79,
+            Mode = Mode.Beginner,
+            Exp = 171200
+        };
+
+        protected DbLevel Level79_Mode2 = new DbLevel()
+        {
+            Level = 79,
+            Mode = Mode.Normal,
+            Exp = 214847083
+        };
+
+        protected DbLevel Level79_Mode3 = new DbLevel()
+        {
+            Level = 69,
+            Mode = Mode.Hard,
+            Exp = 214847083
+        };
+
+        protected DbLevel Level79_Mode4 = new DbLevel()
+        {
+            Level = 79,
+            Mode = Mode.Ultimate,
+            Exp = 330854048
+        };
+
+        protected DbLevel Level80_Mode1 = new DbLevel()
+        {
+            Level = 50,
+            Mode = Mode.Beginner,
+            Exp = 171200
+        };
+
+        protected DbLevel Level80_Mode2 = new DbLevel()
+        {
+            Level = 60,
+            Mode = Mode.Normal,
+            Exp = 214847083
+        };
+
+        protected DbLevel Level80_Mode3 = new DbLevel()
+        {
+            Level = 70,
+            Mode = Mode.Hard,
+            Exp = 214847083
+        };
+
+        protected DbLevel Level80_Mode4 = new DbLevel()
+        {
+            Level = 80,
+            Mode = Mode.Ultimate,
+            Exp = 330854048
         };
 
         #endregion

--- a/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterExperienceTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterExperienceTest.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel;
+using Imgeneus.Database.Entities;
+using Imgeneus.World.Game.Monster;
+using Xunit;
+
+namespace Imgeneus.World.Tests.CharacterTests
+{
+    public class CharacterExperienceTest : BaseTest
+    {
+        [Fact]
+        [Description("Character level should be updated with experience changes.")]
+        public void LevelFromExperienceTest()
+        {
+            var character = CreateCharacter();
+
+            character.TrySetMode(Mode.Ultimate);
+            character.TryChangeLevel(1);
+            character.TryChangeExperience(0);
+
+            Assert.Equal((uint)0, character.Exp);
+
+            character.TryAddExperience(201);
+
+            Assert.Equal((uint)201, character.Exp);
+            Assert.Equal(2, character.Level);
+        }
+
+        [Fact]
+        [Description("Character shouldn't receive experience if already at maximum level")]
+        public void ExperienceBoundaryTest()
+        {
+            var character = CreateCharacter();
+
+            var maxLevel = config.Object.GetMaxLevelConfig(character.Mode).Level;
+
+            character.TrySetMode(Mode.Ultimate);
+            character.TryChangeLevel(maxLevel, true);
+
+            Assert.Equal(maxLevel, character.Level);
+
+            var maxLevelExp = databasePreloader.Object.Levels[(character.Mode, character.Level)].Exp;
+
+            Assert.Equal(maxLevelExp, character.Exp);
+            Assert.False(character.TryAddExperience(1));
+            Assert.Equal(maxLevelExp, character.Exp);
+        }
+
+        [Fact]
+        [Description("Character should receive experience by killing a mob")]
+        public void ExperienceGainFromMobTest()
+        {
+            var map = testMap;
+            var mob = new Mob(Wolf.Id, true, new MoveArea(0, 0, 0, 0, 0, 0), map, mobLoggerMock.Object, databasePreloader.Object);
+
+            var character = CreateCharacter();
+
+            character.TryChangeExperience(40);
+            Assert.Equal((uint)40, character.Exp);
+
+            map.LoadPlayer(character);
+            map.AddMob(mob);
+            mob.DecreaseHP(20000000, character);
+
+            Assert.True(mob.IsDead);
+            Assert.Equal((uint)(40 + mob.Exp), character.Exp);
+        }
+    }
+}

--- a/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterLevelTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterLevelTest.cs
@@ -9,32 +9,41 @@ namespace Imgeneus.World.Tests.CharacterTests
     {
         [Fact]
         [Description("Character level should respect boundaries.")]
-        public void SetLevelTest()
+        public void LevelBoundariesTest()
         {
             var character = CreateCharacter();
 
             character.TrySetMode(Mode.Ultimate);
 
-            // TODO: MaxLevel should be a global property, change this when implemented.
             ushort maxLevel = 80;
 
-            Assert.True(character.TrySetLevel(1));
-            Assert.Equal(1, character.Level);
-
-            Assert.True(character.TrySetLevel(25));
-            Assert.Equal(25, character.Level);
-
-            Assert.True(character.TrySetLevel(maxLevel));
-            Assert.Equal(maxLevel, character.Level);
-
-            Assert.False(character.TrySetLevel((ushort)(maxLevel + 1)));
-            Assert.NotEqual(maxLevel + 1, character.Level);
-
-            Assert.False(character.TrySetLevel(0));
+            Assert.False(character.TryChangeLevel(0));
             Assert.NotEqual(0, character.Level);
 
-            Assert.False(character.TrySetLevel(1000));
+            Assert.False(character.TryChangeLevel((ushort)(maxLevel + 1)));
+            Assert.NotEqual(maxLevel + 1, character.Level);
+
+            Assert.False(character.TryChangeLevel(1000));
             Assert.NotEqual(1000, character.Level);
+        }
+
+        [Fact]
+        [Description("Character level can't be changed to same level.")]
+        public void LevelChangeTest()
+        {
+            var character = CreateCharacter();
+
+            character.TrySetMode(Mode.Ultimate);
+
+            ushort maxLevel = 80;
+
+            Assert.True(character.TryChangeLevel(2));
+            Assert.False(character.TryChangeLevel(2));
+            Assert.Equal(2, character.Level);
+
+            Assert.True(character.TryChangeLevel(maxLevel));
+            Assert.False(character.TryChangeLevel(maxLevel));
+            Assert.Equal(maxLevel, character.Level);
         }
     }
 }

--- a/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterStatsTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterStatsTest.cs
@@ -16,17 +16,17 @@ namespace Imgeneus.World.Tests.CharacterTests
 
             character.TrySetMode(Mode.Ultimate);
 
-            ushort level = 10;
-            character.TrySetLevel(level);
+            ushort level = 80;
+            character.TryChangeLevel(level);
             character.ResetStats();
 
-            Assert.Equal(12 + 9, character.Strength); // 12 is default + 9 str per each level
+            Assert.Equal(12 + 79, character.Strength); // 12 is default + 1 str per each level
             Assert.Equal(11, character.Dexterity);
             Assert.Equal(10, character.Reaction);
             Assert.Equal(8, character.Intelligence);
             Assert.Equal(9, character.Wisdom);
             Assert.Equal(10, character.Luck);
-            Assert.Equal(81, character.StatPoint);
+            Assert.Equal(711, character.StatPoint);
         }
 
         [Fact]


### PR DESCRIPTION
Players now get experience from mobs only if they're not max level. Levels are updated accordingly based on experience values. GM commands `/set level` and `/set exp` were updated accordingly.
Players nearby are also notified of player's level up and can see the leveling effect animation.

Missing implementations for leveling:
- Share experience between parties
- Send level update to party members on the party tab