### PR TITLE
Character stats

### DIFF
--- a/src/Imgeneus.World/Game/Player/CharacterStats.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterStats.cs
@@ -712,29 +712,67 @@ namespace Imgeneus.World.Game.Player
             switch (statAttribute)
             {
                 case CharacterAttributeEnum.Strength:
-                    Strength = newStatValue;
+                    SetStat(CharacterStatEnum.Strength, newStatValue);
                     break;
 
                 case CharacterAttributeEnum.Dexterity:
-                    Dexterity = newStatValue;
-                    SendMaxSP();
+                    SetStat(CharacterStatEnum.Dexterity, newStatValue);
                     break;
 
                 case CharacterAttributeEnum.Reaction:
-                    Reaction = newStatValue;
-                    SendMaxHP();
+                    SetStat(CharacterStatEnum.Reaction, newStatValue);
                     break;
 
                 case CharacterAttributeEnum.Intelligence:
-                    Intelligence = newStatValue;
+                    SetStat(CharacterStatEnum.Intelligence, newStatValue);
                     break;
 
                 case CharacterAttributeEnum.Luck:
-                    Luck = newStatValue;
+                    SetStat(CharacterStatEnum.Luck, newStatValue);
                     break;
 
                 case CharacterAttributeEnum.Wisdom:
-                    Wisdom = newStatValue;
+                    SetStat(CharacterStatEnum.Wisdom, newStatValue);
+                    break;
+
+                default:
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// Change a character's stat value.
+        /// </summary>
+        /// <param name="stat">Stat to change</param>
+        /// <param name="value">New stat value</param>
+        public void SetStat(CharacterStatEnum stat, ushort value)
+        {
+            switch (stat)
+            {
+                case CharacterStatEnum.Strength:
+                    Strength = value;
+                    break;
+
+                case CharacterStatEnum.Dexterity:
+                    Dexterity = value;
+                    SendMaxSP();
+                    break;
+
+                case CharacterStatEnum.Reaction:
+                    Reaction = value;
+                    SendMaxHP();
+                    break;
+
+                case CharacterStatEnum.Intelligence:
+                    Intelligence = value;
+                    break;
+
+                case CharacterStatEnum.Luck:
+                    Luck = value;
+                    break;
+
+                case CharacterStatEnum.Wisdom:
+                    Wisdom = value;
                     SendMaxMP();
                     break;
 

--- a/src/Imgeneus.World/Game/Player/CharacterStats.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterStats.cs
@@ -113,7 +113,7 @@ namespace Imgeneus.World.Game.Player
         {
             get
             {
-                return ConstHP + ExtraHP;
+                return ConstHP + ExtraHP + ReactionExtraHP;
             }
         }
 
@@ -136,7 +136,7 @@ namespace Imgeneus.World.Game.Player
         {
             get
             {
-                return ConstMP + ExtraMP;
+                return ConstMP + ExtraMP + WisdomExtraMP;
             }
         }
 
@@ -159,7 +159,7 @@ namespace Imgeneus.World.Game.Player
         {
             get
             {
-                return ConstSP + ExtraSP;
+                return ConstSP + ExtraSP + DexterityExtraSP;
             }
         }
 
@@ -302,6 +302,19 @@ namespace Imgeneus.World.Game.Player
                     break;
             }
         }
+        /// Extra HP given by Reaction formula
+        /// </summary>
+        public int ReactionExtraHP => Reaction * 5;
+
+        /// <summary>
+        /// Extra MP given by Wisdom formula
+        /// </summary>
+        public int WisdomExtraMP => Wisdom * 5;
+
+        /// <summary>
+        /// Extra SP given by Dexterity formula
+        /// </summary>
+        public int DexterityExtraSP => Dexterity * 5;
 
         #endregion
 
@@ -701,24 +714,35 @@ namespace Imgeneus.World.Game.Player
                 case CharacterAttributeEnum.Strength:
                     Strength = newStatValue;
                     break;
+
                 case CharacterAttributeEnum.Dexterity:
                     Dexterity = newStatValue;
+                    SendMaxSP();
                     break;
+
                 case CharacterAttributeEnum.Reaction:
                     Reaction = newStatValue;
+                    SendMaxHP();
                     break;
+
                 case CharacterAttributeEnum.Intelligence:
                     Intelligence = newStatValue;
                     break;
+
                 case CharacterAttributeEnum.Luck:
                     Luck = newStatValue;
                     break;
+
                 case CharacterAttributeEnum.Wisdom:
                     Wisdom = newStatValue;
+                    SendMaxMP();
                     break;
+
                 default:
                     return;
             }
+
+            SendAdditionalStats();
 
             _taskQueue.Enqueue(ActionType.UPDATE_STATS, Id, Strength, Dexterity, Reaction, Intelligence, Wisdom, Luck, StatPoint);
         }

--- a/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterStatsTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterStatsTest.cs
@@ -36,12 +36,12 @@ namespace Imgeneus.World.Tests.CharacterTests
             var character = CreateCharacter();
 
             character.TrySetMode(Mode.Ultimate);
-            character.SetStat(CharacterAttributeEnum.Strength, 1);
-            character.SetStat(CharacterAttributeEnum.Dexterity, 2);
-            character.SetStat(CharacterAttributeEnum.Reaction, 3);
-            character.SetStat(CharacterAttributeEnum.Intelligence, 4);
-            character.SetStat(CharacterAttributeEnum.Wisdom, 5);
-            character.SetStat(CharacterAttributeEnum.Luck, 6);
+            character.SetStat(CharacterStatEnum.Strength, 1);
+            character.SetStat(CharacterStatEnum.Dexterity, 2);
+            character.SetStat(CharacterStatEnum.Reaction, 3);
+            character.SetStat(CharacterStatEnum.Intelligence, 4);
+            character.SetStat(CharacterStatEnum.Wisdom, 5);
+            character.SetStat(CharacterStatEnum.Luck, 6);
 
             ushort newStatValue = 77;
 
@@ -52,12 +52,12 @@ namespace Imgeneus.World.Tests.CharacterTests
             Assert.NotEqual(newStatValue, character.Wisdom);
             Assert.NotEqual(newStatValue, character.Luck);
 
-            character.SetStat(CharacterAttributeEnum.Strength, newStatValue);
-            character.SetStat(CharacterAttributeEnum.Dexterity, newStatValue);
-            character.SetStat(CharacterAttributeEnum.Intelligence, newStatValue);
-            character.SetStat(CharacterAttributeEnum.Reaction, newStatValue);
-            character.SetStat(CharacterAttributeEnum.Wisdom, newStatValue);
-            character.SetStat(CharacterAttributeEnum.Luck, newStatValue);
+            character.SetStat(CharacterStatEnum.Strength, newStatValue);
+            character.SetStat(CharacterStatEnum.Dexterity, newStatValue);
+            character.SetStat(CharacterStatEnum.Intelligence, newStatValue);
+            character.SetStat(CharacterStatEnum.Reaction, newStatValue);
+            character.SetStat(CharacterStatEnum.Wisdom, newStatValue);
+            character.SetStat(CharacterStatEnum.Luck, newStatValue);
 
             Assert.Equal(newStatValue, character.Strength);
             Assert.Equal(newStatValue, character.Dexterity);
@@ -65,6 +65,29 @@ namespace Imgeneus.World.Tests.CharacterTests
             Assert.Equal(newStatValue, character.Reaction);
             Assert.Equal(newStatValue, character.Wisdom);
             Assert.Equal(newStatValue, character.Luck);
+        }
+
+        [Fact]
+        [Description("Character's max HP, MP and SP should be incremented with REC, WIS and DEX")]
+        public void VitalityTest()
+        {
+            var character = CreateCharacter();
+
+            character.SetStat(CharacterStatEnum.Reaction, 0);
+            character.SetStat(CharacterStatEnum.Wisdom, 0);
+            character.SetStat(CharacterStatEnum.Dexterity, 0);
+
+            var previousHP = character.MaxHP;
+            var previousMP = character.MaxMP;
+            var previousSP = character.MaxSP;
+
+            character.SetStat(CharacterStatEnum.Reaction, 5);
+            character.SetStat(CharacterStatEnum.Wisdom, 10);
+            character.SetStat(CharacterStatEnum.Dexterity, 15);
+
+            Assert.Equal(previousHP + 25, character.MaxHP);
+            Assert.Equal(previousMP + 50, character.MaxMP);
+            Assert.Equal(previousSP + 75, character.MaxSP);
         }
     }
 }


### PR DESCRIPTION
Small changes to include Rec, Wis and Dex to HP, MP and SP formulas. I checked on OS and it's `1 rec = 5 HP,  1 dex = 5 SP and 1 wis = 5 MP`. I also added the calls to send the appropriate HP, SP MP and Attack/Resist/Magic attack/Magic Resist when stats are changed.