### PR TITLE
Mount speed bug fix

### DIFF
--- a/src/Imgeneus.World/Game/Player/CharacterInventory.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterInventory.cs
@@ -310,6 +310,10 @@ namespace Imgeneus.World.Game.Player
             set
             {
                 TakeOffItem(_mount);
+
+                // Remove mount if user was mounted while switching mount
+                RemoveVehicle();
+
                 _mount = value;
                 TakeOnItem(_mount);
 
@@ -465,7 +469,9 @@ namespace Imgeneus.World.Game.Player
 
             if (item != Weapon && item != Mount)
                 SetAttackSpeedModifier(-1 * item.AttackSpeed);
-            MoveSpeed -= item.MoveSpeed;
+
+            if(item != Mount)
+                MoveSpeed -= item.MoveSpeed;
         }
 
         /// <summary>
@@ -490,7 +496,9 @@ namespace Imgeneus.World.Game.Player
 
             if (item != Weapon && item != Mount)
                 SetAttackSpeedModifier(item.AttackSpeed);
-            MoveSpeed += item.MoveSpeed;
+
+            if(item != Mount)
+                MoveSpeed += item.MoveSpeed;
         }
 
         #endregion

--- a/src/Imgeneus.World/Game/Player/CharacterVehicle.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterVehicle.cs
@@ -35,7 +35,7 @@ namespace Imgeneus.World.Game.Player
         }
 
         /// <summary>
-        /// Event, that is fired, when the player starts summoning mount. 
+        /// Event, that is fired, when the player starts summoning mount.
         /// </summary>
         public event Action<Character> OnStartSummonVehicle;
 
@@ -61,12 +61,16 @@ namespace Imgeneus.World.Game.Player
         /// <summary>
         /// Tries to summon vehicle(mount).
         /// </summary>
-        public void CallVehicle()
+        /// <param name="skipSummoning">Indicates whether the summon casting time should be skipped or not.</param>
+        public void CallVehicle(bool skipSummoning = false)
         {
             if (Mount is null || IsStealth)
                 return;
 
-            IsSummmoningVehicle = true;
+            if (skipSummoning)
+                IsOnVehicle = true;
+            else
+                IsSummmoningVehicle = true;
         }
 
         /// <summary>

--- a/src/UnitTests/Imgeneus.World.Tests/BaseTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/BaseTest.cs
@@ -140,7 +140,8 @@ namespace Imgeneus.World.Tests
                     { (30, 3), Gem_Str_Level_3 },
                     { (30, 7), Gem_Str_Level_7 },
                     { (100, 1), EtainPotion },
-                    { (25, 1), RedApple }
+                    { (25, 1), RedApple },
+                    { (42, 1), HorseSummonStone }
                 });
 
             databasePreloader
@@ -464,6 +465,12 @@ namespace Imgeneus.World.Tests
             TypeId = 1,
             Special = SpecialEffect.HealingPotion,
             ConstHP = 50
+        };
+
+        protected DbItem HorseSummonStone = new DbItem()
+        {
+            Type = 42,
+            TypeId = 1
         };
 
         #endregion

--- a/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterVehicleTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/CharacterTests/CharacterVehicleTest.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using Imgeneus.World.Game.Player;
+using Xunit;
+
+namespace Imgeneus.World.Tests.CharacterTests
+{
+    public class CharacterVehicleTest : BaseTest
+    {
+        [Fact]
+        [Description("Character's movement speed should increase while using a mount.")]
+        public void CharacterMountTest()
+        {
+            var character = CreateCharacter();
+
+            character.AddItemToInventory(new Item(databasePreloader.Object, HorseSummonStone.Type, HorseSummonStone.TypeId));
+            character.Mount = character.InventoryItems[(1, 0)];
+
+            character.CallVehicle(true);
+            Assert.Equal((int)MoveSpeedEnum.VeryFast, character.MoveSpeed);
+
+            character.RemoveVehicle();
+            Assert.Equal((int)MoveSpeedEnum.Normal, character.MoveSpeed);
+        }
+
+        [Fact]
+        [Description("Character's mount should be removed if equipped mount is changed while still using the previous one.")]
+        public void CharacterMountChangeTest()
+        {
+            var character = CreateCharacter();
+
+            character.AddItemToInventory(new Item(databasePreloader.Object, HorseSummonStone.Type, HorseSummonStone.TypeId));
+            character.AddItemToInventory(new Item(databasePreloader.Object, HorseSummonStone.Type, HorseSummonStone.TypeId));
+
+            // Equip mount 1
+            character.Mount = character.InventoryItems[(1, 0)];
+            character.CallVehicle(true);
+            Assert.Equal((int)MoveSpeedEnum.VeryFast, character.MoveSpeed);
+
+            // Equip mount 2
+            character.Mount = character.InventoryItems[(1, 1)];
+            Assert.Equal((int)MoveSpeedEnum.Normal, character.MoveSpeed);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes this bug: _**While a mount is active, if it's replaced by another mount item, the mount's movement speed will remain as part of the character's movement speed as if it had a sonic lapis linked.**_

I replicated the OS behavior, if the mount item is changed while the character is mounted, it will be unmounted. And also the speed problem is fixed aswell.

Since equipping mounts requires a summoning time managed by a timer, it's hard to test or at least I couldn't find an easy way to do it, so I added a parameter on the call vehicle method: 
```cs
public void CallVehicle(bool skipSummoning = false)
```
This will skip the timer and mount the character as soon as the action is requested. This can be useful in certain situations like making admins skip the summoning time or whatever. I don't know if you'll like it though @aosyatnik.