### PR TITLE
fix for login issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Any game feature must have a corresponding unit test.
 * maybe __YOU__?
 
 ## Uknown issues
-1. Sometimes Login server can not decrypt the first packet (with user name and password). Try to restart game.exe several times. Might be, that client caches old encryption key (not sure).
-2. Many others, usually marked as `// TODO: <some comment>` throughout the code base.
+Issues are usually marked as `// TODO: <some comment>` throughout the code base.
 
 Find the current state of development [here](https://trello.com/b/lHvyQDuH/shaiya-imgeneus).

--- a/src/Imgeneus.Network/Packets/Login/LoginHandshakePacket.cs
+++ b/src/Imgeneus.Network/Packets/Login/LoginHandshakePacket.cs
@@ -1,6 +1,6 @@
 ﻿using Imgeneus.Network.Data;
 using Imgeneus.Network.Packets.Game;
-using System.Linq;
+using System;
 using System.Numerics;
 
 namespace Imgeneus.Network.Packets.Login
@@ -11,15 +11,13 @@ namespace Imgeneus.Network.Packets.Login
 
         public LoginHandshakePacket(IPacketStream packet)
         {
-            var encryptedBytes = packet.Buffer.Skip(5).ToArray(); // 128 bytes here
-
-            // Again endian problem. Client sends big integer as small endian, but BigInteger in c# is big endian.
-            // So what we need to do in this case: we should reverse array and add 0-byte as first byte.
-            // From here: https://stackoverflow.com/questions/48372017/convert-byte-array-to-biginteger
-            // Example: client sends [2, 20, 200] we trasform to [0, 200, 20, 2]
-            byte[] rev = new byte[encryptedBytes.Length + 1];
-            for (int i = 0, j = encryptedBytes.Length; j > 0; i++, j--)
-                rev[j] = encryptedBytes[i];
+            // NB! 129 is one byte more, than client sends. The reason for this:
+            // By creating a byte array either dynamically or statically without necessarily calling any of the previous methods, or by modifying an existing byte array.
+            // To prevent positive values from being misinterpreted as negative values, you can add a zero-byte value to the end of the array.
+            // You can read more here: https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger.-ctor
+            // So, the last byte is always zero-byte.
+            var encryptedBytes = new byte[129];
+            Array.Copy(packet.Buffer, 5, encryptedBytes, 0, packet.Length - 5);
 
             EncyptedNumber = new BigInteger(encryptedBytes);
         }


### PR DESCRIPTION
The server was interpreting a random number, generated by a client as a negative number sometimes. Added 0-byte in the end as per doc:

> By creating a byte array either dynamically or statically without necessarily calling any of the previous methods, or by modifying an existing byte array. To prevent positive values from being misinterpreted as negative values, **you can add a zero-byte value to the end of the array**.

Seems to work for me.