### PR TITLE
Character name validation

### DIFF
--- a/src/Imgeneus.Core/Extensions/StringExtensions.cs
+++ b/src/Imgeneus.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Imgeneus.Core.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool IsValidCharacterName(this string name)
+        {
+            // Validate length
+            if (name.Length < 3 || name.Length > 20)
+                return false;
+
+            // Validate allowed characters
+            var validCharsPattern = @"[a-zA-Z0-9-_.]";
+
+            if (!Regex.IsMatch(name, validCharsPattern))
+                return false;
+
+            // Don't allow more than 6 digits or names that only have digits
+            var digitCount = name.Count(char.IsDigit);
+
+            if (digitCount > 6 || name.Length == digitCount)
+                return false;
+
+            // Don't allow more than 6 symbols or names that only have symbols
+            var symbolCount = name.Count(c => c == '-' || c == '_' || c == '.');
+
+            if (symbolCount > 6 || name.Length == symbolCount)
+                return false;
+
+            // Don't allow two consecutive equal symbols
+            if (name.Contains("..") || name.Contains("--") || name.Contains("__"))
+                return false;
+
+            // Don't allow more than 6 I and l because cheaters usually use names that look like "||||||||" in-game so that it's harder for them to get banned.
+            var combinationCount = name.Count(c => c == 'l' || c == 'I');
+
+            if (combinationCount > 6)
+                return false;
+
+            // Validate prohibited starting tags
+            var staffPattern = @"^(\[(?:DEVELOPER|ADM(?:IN)?|DEV|TGS|G(?:MA|S)|GM)\]|DEVELOPER|ADMIN|DEV|ADM|TGS|G(?:MA|S)|GM)";
+
+            if (Regex.IsMatch(name, staffPattern))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/Imgeneus.Core/Extensions/StringExtensions.cs
+++ b/src/Imgeneus.Core/Extensions/StringExtensions.cs
@@ -36,7 +36,7 @@ namespace Imgeneus.Core.Extensions
             // Don't allow more than 6 I and l because cheaters usually use names that look like "||||||||" in-game so that it's harder for them to get banned.
             var combinationCount = name.Count(c => c == 'l' || c == 'I');
 
-            if (combinationCount > 6)
+            if (combinationCount > 6 || name.Length == combinationCount)
                 return false;
 
             // Validate prohibited starting tags

--- a/src/UnitTests/Imgeneus.World.Tests/ExtensionTests/CharnameValidationTest.cs
+++ b/src/UnitTests/Imgeneus.World.Tests/ExtensionTests/CharnameValidationTest.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using Imgeneus.Core.Extensions;
+using Xunit;
+
+namespace Imgeneus.World.Tests.ExtensionTests
+{
+    public class CharnameValidationTest : BaseTest
+    {
+
+        [Theory]
+        [Description("Charname shouldn't allow banned tags or")]
+        [InlineData("ON", false)]
+        [InlineData("ONE", true)]
+        [InlineData("TWENTYONECHARACTERNAM", false)]
+        [InlineData("TWENTYCHARACTERNAMEE", true)]
+        [InlineData("-_-Olive-_-", true)]
+        [InlineData("-_-_-_-Olive-_-_-_-", false)]
+        [InlineData(".Michael.", true)]
+        [InlineData("..Michael..", false)]
+        [InlineData(".-Michael-.", true)]
+        [InlineData("000Agent000", true)]
+        [InlineData("0123Agent0123", false)]
+        [InlineData("01234", false)]
+        [InlineData("lullabyllel", true)]
+        [InlineData("lullabyllell", false)]
+        [InlineData("IIIlllIl", false)]
+        [InlineData("[GS]Toby", false)]
+        [InlineData("GSToby", false)]
+        [InlineData("BUGSBUNNY", true)]
+        [InlineData("[TGS]Alfred", false)]
+        [InlineData("TGSAlfred", false)]
+        [InlineData("NUMTGS", true)]
+        [InlineData("[GM]Nobody", false)]
+        [InlineData("GMNobody", false)]
+        [InlineData("SEGMENTATION", true)]
+        [InlineData("[GMA]Pure", false)]
+        [InlineData("GMAPure", false)]
+        [InlineData("STIGMATIZE", true)]
+        [InlineData("[ADM]Faith", false)]
+        [InlineData("ADMFaith", false)]
+        [InlineData("THEADMIRAL", true)]
+        [InlineData("[DEV]Fire", false)]
+        [InlineData("DEVFire", false)]
+        [InlineData("NONDEVIANT", true)]
+        [InlineData("[DEVELOPER]Bunny", false)]
+        [InlineData("DEVELOPERBunny", false)]
+        public void CharacterNameValidationTest(string name, bool isValid)
+        {
+            Assert.Equal(isValid, name.IsValidCharacterName());
+        }
+    }
+}


### PR DESCRIPTION
Added validation for character names both on character creation and on name change.

The proposed validation implementation is simple yet it covers a huge amount of potential undesired names. This could be extended in the future to provide a custom list of staff tags to avoid and also offensive words.

**Proposed validation**:
- Allowed characters: `a-z`, `A-Z`, `0-9`, `-`, `_` and `.`
    - `#@ζζ*&^%$!~\/?><` ❌ 
    - `-Mati123._` ✅ 
- Names can only contain up to `6` digits.
    - `01234Mati56789` ❌ 
    - `123Mati456` ✅ 
- Names that only contain digits `0-9` are not allowed.
    - `0123456789` ❌ 
    - `Mati001` ✅ 
- Names can only contain up to `6` symbols (`-`, `_` and `.`)
    - `_-_-_-Mati-_-_-_` ❌ 
    - `-_-Mati-_-` ✅ 
- Names that only contain symbols are not allowed
    - `....-_-....` ❌ 
    - `._-Mati-_.` ✅ 
- Names can't have 2 equal consecutive symbols
     - `....Mati....` ❌ 
     - `-_-Mati-_-` ✅ 
- Names that contain only `l (lowercase L)` and `I (uppercase i)` are not allowed. This could result in names like `IIIIIIllllllll` which are impossible to deal with in-game because both characters look the same. I've seen cheaters use these kind of names so that it takes longer for them to get banned
    - `lIlIlIlIlI` ❌ 
    - `Matillll123` ✅ 
- Names can't contain more than 6  `l (lowercase L)` and `I (uppercase i)` characters combined
    - `lllllMatilllll` ❌ 
    - `llMatill` ✅ 
- Names can't start with staff tags such as `GS`, `TGS`, `GM`, `GMA`, `ADM`, `ADMIN`, `DEV` or `DEVELOPER`, but they can include it in their names to avoid prohibiting names that include those combinations
    - `ADMMati` ❌ 
    - `THE_ADMIRAL` ✅ 

After investigating for a bit, I couldn't find any packets for server side validation. I think OS's server trusts the client's validation but I'm not sure. For the moment, this validation will return the "Name is already in use" packet for invalid character names.