### PR TITLE
/amove fixes

### DIFF
--- a/src/Imgeneus.World/Game/IGameWorld.cs
+++ b/src/Imgeneus.World/Game/IGameWorld.cs
@@ -2,6 +2,7 @@
 using Imgeneus.World.Game.Player;
 using Imgeneus.World.Game.Zone;
 using Imgeneus.World.Game.Zone.Portals;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -22,6 +23,11 @@ namespace Imgeneus.World.Game
         /// Loaded maps. Key is map id, value is map.
         /// </summary>
         ConcurrentDictionary<ushort, IMap> Maps { get; }
+
+        /// <summary>
+        /// Thread-safe dictionary of maps. Where key is party id.
+        /// </summary>
+        ConcurrentDictionary<Guid, IPartyMap> PartyMaps { get; }
 
         /// <summary>
         /// Collection of map ids, that are available for GM teleport.

--- a/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketHandlers.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using Imgeneus.World.Game.Monster;
+using Imgeneus.World.Game.Zone;
+using System.Collections.Generic;
 
 namespace Imgeneus.World.Game.Player
 {
@@ -216,6 +218,14 @@ namespace Imgeneus.World.Game.Player
                 _packetsHelper.SendGmCommandError(Client, PacketType.GM_TELEPORT_TO_PLAYER);
             else
             {
+                // Teleport to party instance map.
+                if (player.Map is IPartyMap)
+                {
+                    SetParty(null);
+                    var mapId = _gameWorld.PartyMaps.FirstOrDefault(m => m.Value == player.Map).Key;
+                    PreviousPartyId = mapId;
+                }
+
                 Teleport(player.MapId, player.PosX, player.PosY, player.PosZ);
 
                 _packetsHelper.SendGmCommandSuccess(Client);

--- a/src/Imgeneus.World/Game/Player/CharacterTeleport.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterTeleport.cs
@@ -47,21 +47,14 @@ namespace Imgeneus.World.Game.Player
             if (prevMapId == MapId)
             {
                 Map.TeleportPlayer(Id, teleportedByAdmin);
+                IsTeleporting = false;
             }
             else // But we must always send the teleport packet directly to the player.
             {
                 _packetsHelper.SendCharacterTeleport(Client, this, teleportedByAdmin);
-            }
-
-            if (prevMapId != MapId)
-            {
                 if (IsDuelApproved)
                     FinishDuel(DuelCancelReason.TooFarAway);
                 Map.UnloadPlayer(this);
-            }
-            else
-            {
-                IsTeleporting = false;
             }
         }
 

--- a/src/Imgeneus.World/Game/Player/CharacterTeleport.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterTeleport.cs
@@ -42,7 +42,17 @@ namespace Imgeneus.World.Game.Player
             _taskQueue.Enqueue(ActionType.SAVE_MAP_ID, Id, MapId);
             _taskQueue.Enqueue(ActionType.SAVE_CHARACTER_MOVE, Id, x, y, z, Angle);
 
-            Map.TeleportPlayer(Id, teleportedByAdmin);
+            // If player is teleported inside one map, we should notify other players about this teleport.
+            // If player is teleported to another map, we should only send player left map packet (in Map.UnloadPlayer call).
+            if (prevMapId == MapId)
+            {
+                Map.TeleportPlayer(Id, teleportedByAdmin);
+            }
+            else // But we must always send the teleport packet directly to the player.
+            {
+                _packetsHelper.SendCharacterTeleport(Client, this, teleportedByAdmin);
+            }
+
             if (prevMapId != MapId)
             {
                 if (IsDuelApproved)

--- a/src/Imgeneus.World/Game/Zone/MapCell.cs
+++ b/src/Imgeneus.World/Game/Zone/MapCell.cs
@@ -181,16 +181,8 @@ namespace Imgeneus.World.Game.Zone
         /// <param name="teleportedByAdmin">Indicates whether the teleport was issued by an admin or not</param>
         public void TeleportPlayer(Character character, bool teleportedByAdmin)
         {
-            if (teleportedByAdmin)
-            {
-                foreach (var p in GetAllPlayers(true))
-                    _packetsHelper.SendGmTeleport(p.Client, character);
-            }
-            else
-            {
-                foreach (var p in GetAllPlayers(true))
-                    _packetsHelper.SendCharacterTeleport(p.Client, character);
-            }
+            foreach (var p in GetAllPlayers(true))
+                _packetsHelper.SendCharacterTeleport(p.Client, character, teleportedByAdmin);
         }
 
         /// <summary>

--- a/src/Imgeneus.World/Packets/PacketsHelper.cs
+++ b/src/Imgeneus.World/Packets/PacketsHelper.cs
@@ -39,9 +39,9 @@ namespace Imgeneus.World.Packets
             client.SendPacket(packet);
         }
 
-        internal void SendCharacterTeleport(IWorldClient client, Character player)
+        internal void SendCharacterTeleport(IWorldClient client, Character player, bool teleportedByAdmin)
         {
-            using var packet = new Packet(PacketType.CHARACTER_MAP_TELEPORT);
+            using var packet = new Packet(teleportedByAdmin ? PacketType.CHARACTER_MAP_TELEPORT : PacketType.GM_TELEPORT_MAP_COORDINATES);
             packet.Write(player.Id);
             packet.Write(player.MapId);
             packet.Write(player.PosX);
@@ -320,17 +320,6 @@ namespace Imgeneus.World.Packets
         {
             using var packet = new Packet(PacketType.GM_CMD_ERROR);
             packet.Write((ushort)error);
-            client.SendPacket(packet);
-        }
-
-        internal void SendGmTeleport(IWorldClient client, Character character)
-        {
-            using var packet = new Packet(PacketType.GM_TELEPORT_MAP_COORDINATES);
-            packet.Write(character.Id);
-            packet.Write(character.MapId);
-            packet.Write(character.PosX);
-            packet.Write(character.PosY);
-            packet.Write(character.PosZ);
             client.SendPacket(packet);
         }
 


### PR DESCRIPTION
Fixes 2 issues:
* `/amove` should teleport player to party instance map, if needed.
* There was a mismatch with OS packet queue when teleporting between maps. If a player is teleported to another map, we should send only 0x0202 packet, which is `CHARACTER_LEFT_MAP` to **other players**. If a player is teleported in the same map, we should send 0x020B  to **other players**. But we always have to send 0x020B packet to **the teleported player**. All this I got, by RE os server ep 4.