### PR TITLE
Fix inventory crash if number of items >=80

### DIFF
--- a/src/Imgeneus.World/Game/Player/CharacterPacketSenders.cs
+++ b/src/Imgeneus.World/Game/Player/CharacterPacketSenders.cs
@@ -17,7 +17,7 @@ namespace Imgeneus.World.Game.Player
             SendDetails();
             SendAdditionalStats();
             SendCurrentHitpoints();
-            SendInventoryItems(); // TODO: game.exe crashes, when number of items >= 80. Investigate why?
+            SendInventoryItems();
             SendLearnedSkills();
             SendOpenQuests();
             SendFinishedQuests();
@@ -37,7 +37,7 @@ namespace Imgeneus.World.Game.Player
 
         private void SendInventoryItems()
         {
-            var inventoryItems = InventoryItems.Values.ToList();
+            var inventoryItems = InventoryItems.Values.ToArray();
             _packetsHelper.SendInventoryItems(Client, inventoryItems);
 
             foreach (var item in inventoryItems.Where(i => i.ExpirationTime != null))

--- a/src/Imgeneus.World/Packets/PacketsHelper.cs
+++ b/src/Imgeneus.World/Packets/PacketsHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Imgeneus.Database.Constants;
 using Imgeneus.Database.Entities;
@@ -42,12 +41,10 @@ namespace Imgeneus.World.Packets
             {
                 var startIndex = i * 50;
                 var length = i == steps ? left : 50;
-
-                Item[] temp = new Item[length];
-                Array.Copy(inventoryItems, startIndex, temp, 0, length);
+                var endIndex = startIndex + length;
 
                 using var packet = new Packet(PacketType.CHARACTER_ITEMS);
-                packet.Write(new InventoryItems(temp).Serialize());
+                packet.Write(new InventoryItems(inventoryItems[startIndex..endIndex]).Serialize());
                 client.SendPacket(packet);
             }
         }

--- a/src/Imgeneus.World/Packets/PacketsHelper.cs
+++ b/src/Imgeneus.World/Packets/PacketsHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Imgeneus.Database.Constants;
 using Imgeneus.Database.Entities;
@@ -32,11 +33,23 @@ namespace Imgeneus.World.Packets
     /// </summary>
     internal class PacketsHelper
     {
-        internal void SendInventoryItems(IWorldClient client, ICollection<Item> inventoryItems)
+        internal void SendInventoryItems(IWorldClient client, Item[] inventoryItems)
         {
-            using var packet = new Packet(PacketType.CHARACTER_ITEMS);
-            packet.Write(new InventoryItems(inventoryItems).Serialize());
-            client.SendPacket(packet);
+            var steps = inventoryItems.Length / 50;
+            var left = inventoryItems.Length % 50;
+
+            for (var i = 0; i <= steps; i++)
+            {
+                var startIndex = i * 50;
+                var length = i == steps ? left : 50;
+
+                Item[] temp = new Item[length];
+                Array.Copy(inventoryItems, startIndex, temp, 0, length);
+
+                using var packet = new Packet(PacketType.CHARACTER_ITEMS);
+                packet.Write(new InventoryItems(temp).Serialize());
+                client.SendPacket(packet);
+            }
         }
 
         internal void SendCharacterTeleport(IWorldClient client, Character player, bool teleportedByAdmin)


### PR DESCRIPTION
This bug was bothering me too long.
I checked os ep 4, it sends 50 items per packet, I'm doing the same now. The crash is fixed.