### PR TITLE
WIP: Primitive handling of the OAuth login request.

### DIFF
--- a/src/Imgeneus.Login/Login/LoginManager.cs
+++ b/src/Imgeneus.Login/Login/LoginManager.cs
@@ -61,10 +61,21 @@ namespace Imgeneus.Login
             var parts = packet.key.Split(":");
             var username = parts.FirstOrDefault();
             var password = parts.LastOrDefault();
+
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+            {
+                /*
+                 * The client doesn't handle unsuccessful login responses after attempting to login with an OAuth key,
+                 * as it expects the key to always be valid (having been authenticated in a prior step via the updater).
+                 */
+                _client.Disconnect();
+                return;
+            }
+            
             HandleAuthentication(username, password);
         }
 
-        private void HandleAuthentication(String username, String password)
+        private void HandleAuthentication(string username, string password)
         {
             var result = Authentication(username, password);
             if (result != AuthenticationResult.SUCCESS)

--- a/src/Imgeneus.Login/Login/LoginManager.cs
+++ b/src/Imgeneus.Login/Login/LoginManager.cs
@@ -38,7 +38,10 @@ namespace Imgeneus.Login
             switch (packet)
             {
                 case AuthenticationPacket authenticationPacket:
-                    HandleAuthentication(authenticationPacket);
+                    HandleLoginRequest(authenticationPacket);
+                    break;
+                case OAuthAuthenticationPacket oauthPacket:
+                    HandleOauthAuthentication(oauthPacket);
                     break;
                 case SelectServerPacket selectServerPacket:
                     HandleSelectServer(selectServerPacket);
@@ -46,17 +49,31 @@ namespace Imgeneus.Login
             }
         }
 
-        private void HandleAuthentication(AuthenticationPacket authenticationPacket)
+        private void HandleLoginRequest(AuthenticationPacket authenticationPacket)
         {
-            var result = Authentication(authenticationPacket.Username, authenticationPacket.Password);
+            HandleAuthentication(authenticationPacket.Username, authenticationPacket.Password);
+        }
 
+        private void HandleOauthAuthentication(OAuthAuthenticationPacket packet)
+        {
+            // TODO(OAuth): Should we actually implement OAuth? Perhaps a custom updater distribution is desired.
+            // For now, let's just parse the key as a username/password combination.
+            var parts = packet.key.Split(":");
+            var username = parts.FirstOrDefault();
+            var password = parts.LastOrDefault();
+            HandleAuthentication(username, password);
+        }
+
+        private void HandleAuthentication(String username, String password)
+        {
+            var result = Authentication(username, password);
             if (result != AuthenticationResult.SUCCESS)
             {
                 LoginPacketFactory.AuthenticationFailed(_client, result);
                 return;
             }
 
-            DbUser dbUser = _database.Users.First(x => x.Username.Equals(authenticationPacket.Username, StringComparison.OrdinalIgnoreCase));
+            DbUser dbUser = _database.Users.First(x => x.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
 
             if (_server.IsClientConnected(dbUser.Id))
             {

--- a/src/Imgeneus.Login/LoginClient.cs
+++ b/src/Imgeneus.Login/LoginClient.cs
@@ -96,6 +96,7 @@ namespace Imgeneus.Login
         {
             { PacketType.LOGIN_HANDSHAKE, (s) => new LoginHandshakePacket(s) },
             { PacketType.LOGIN_REQUEST, (s) => new AuthenticationPacket(s) },
+            { PacketType.OAUTH_LOGIN_REQUEST, (s) => new OAuthAuthenticationPacket(s) },
             { PacketType.SELECT_SERVER, (s) =>  new SelectServerPacket(s) }
         };
 

--- a/src/Imgeneus.Network/Packets/Login/OAuthAuthenticationPacket.cs
+++ b/src/Imgeneus.Network/Packets/Login/OAuthAuthenticationPacket.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Imgeneus.Network.Data;
+using Imgeneus.Network.Packets.Game;
+
+namespace Imgeneus.Network.Packets.Login
+{
+    public struct OAuthAuthenticationPacket : IEquatable<OAuthAuthenticationPacket>, IDeserializedPacket
+    {
+        public String key { get; }
+
+        public OAuthAuthenticationPacket(IPacketStream stream)
+        {
+            key = stream.ReadString(40);
+        }
+
+        public bool Equals(OAuthAuthenticationPacket other)
+        {
+            return other.key == key;
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/PacketType.cs
+++ b/src/Imgeneus.Network/Packets/PacketType.cs
@@ -28,6 +28,7 @@
         // Login Server
         LOGIN_HANDSHAKE = 0xA101, // 41217
         LOGIN_REQUEST = 0xA102,
+        OAUTH_LOGIN_REQUEST = 0xA110,
         SERVER_LIST = 0xA201,
         SELECT_SERVER = 0xA202,
 


### PR DESCRIPTION
This primitive implementation takes an input key as a primitive username:password combination. Perhaps a more fully fleshed out OAuth implementation would be more desirable via a custom launcher and api endpoint.

For launching the Shaiya-US client, the client expects the launch parameters as:
`game.exe login-server-ip oauth-key`