### PR TITLE
Packets: Add support for heartbeat

### DIFF
--- a/src/Imgeneus.Login/Handlers/HeartbeatHandler.cs
+++ b/src/Imgeneus.Login/Handlers/HeartbeatHandler.cs
@@ -1,0 +1,25 @@
+using Imgeneus.Network.Packets;
+using Imgeneus.Network.Packets.Login;
+using InterServer.Server;
+using Sylver.HandlerInvoker.Attributes;
+
+namespace Imgeneus.Login.Handlers
+{
+    [Handler]
+    public class HeartbeatHandler
+    {
+        private readonly IInterServer _interServer;
+
+        public HeartbeatHandler(IInterServer interServer)
+        {
+            _interServer = interServer;
+        }
+
+        [HandlerAction(PacketType.HEARTBEAT)]
+        public void Handle(LoginClient sender, HeartbeatPacket packet)
+        {
+            // the client sends this packet every 120000 milliseconds
+            // to-do: figure out the logic behind closing the connection
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/Game/HeartbeatPacket.cs
+++ b/src/Imgeneus.Network/Packets/Game/HeartbeatPacket.cs
@@ -1,0 +1,11 @@
+using Imgeneus.Network.PacketProcessor;
+
+namespace Imgeneus.Network.Packets.Game
+{
+    public record HeartbeatPacket : IPacketDeserializer
+    {
+        public void Deserialize(ImgeneusPacket packetStream)
+        {
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/Login/HeartbeatPacket.cs
+++ b/src/Imgeneus.Network/Packets/Login/HeartbeatPacket.cs
@@ -1,0 +1,11 @@
+using Imgeneus.Network.PacketProcessor;
+
+namespace Imgeneus.Network.Packets.Login
+{
+    public record HeartbeatPacket : IPacketDeserializer
+    {
+        public void Deserialize(ImgeneusPacket packetStream)
+        {
+        }
+    }
+}

--- a/src/Imgeneus.Network/Packets/PacketType.cs
+++ b/src/Imgeneus.Network/Packets/PacketType.cs
@@ -17,6 +17,7 @@
         CHARACTER_MAX_HP_MP_SP = 0x051F, // 1311
 
         // Common
+        HEARTBEAT = 0x0003,
         LOGOUT = 0x0107, // 263
         CHARACTER_SKILLS = 0x0108,
         ACCOUNT_FACTION = 0x0109, // 265
@@ -236,16 +237,25 @@
         // Chat
         CHAT_NORMAL_ADMIN = 0xF101, // 61697, -3837
         CHAT_WHISPER_ADMIN = 0xF102, // 61698, -3838
+        CHAT_WORLD_ADMIN = 0xF103, // 61699, -3837
         CHAT_GUILD_ADMIN = 0xF104, //  61700, -3836
         CHAT_PARTY_ADMIN = 0xF105, // 61701, -3835
+        CHAT_SERVER_MANAGER_NT = 0xF106, // 61702, -3834
+        CHAT_SEND_TO_FIND_USER = 0xF107, // 61703, -3833
+        CHAT_SEND_TO = 0xF108, // 61704, -3832
+        CHAT_SEND_TO_END = 0xF109, // 61705, -3831
+        CHAT_RAID_ADMIN = 0xF10A, // 61706, -3830
 
         CHAT_NORMAL = 0x1101, // 4353
         CHAT_WHISPER = 0x1102, // 4354
         CHAT_WORLD = 0x1103, // 4355
         CHAT_GUILD = 0x1104, // 4356
         CHAT_PARTY = 0x1105, // 4357
+        CHAT_USER_DOES_NOT_EXIST = 0x1106, // 4358
+        CHAT_SHOUT = 0x1107, // 4359
         CHAT_MESSAGE_TO_SERVER = 0x1108, // 4360
         CHAT_MAP = 0x1111, // 4369
+        CHAT_RAID = 0x1112, // 4370
 
         // Notice
         NOTICE_ADMINS = 0xF906, // 63750

--- a/src/Imgeneus.World/Handlers/HeartbeatHandler.cs
+++ b/src/Imgeneus.World/Handlers/HeartbeatHandler.cs
@@ -1,0 +1,23 @@
+using Imgeneus.Network.Packets;
+using Imgeneus.Network.Packets.Game;
+using Imgeneus.World.Game.Session;
+using Imgeneus.World.Packets;
+using Sylver.HandlerInvoker.Attributes;
+
+namespace Imgeneus.World.Handlers
+{
+    [Handler]
+    public class HeartbeatHandler : BaseHandler
+    {
+        public HeartbeatHandler(IGamePacketFactory packetFactory, IGameSession gameSession) : base(packetFactory, gameSession)
+        {
+        }
+
+        [HandlerAction(PacketType.HEARTBEAT)]
+        public void Handle(WorldClient client, HeartbeatPacket packet)
+        {
+            // the client sends this packet every 120000 milliseconds
+            // to-do: figure out the logic behind closing the connection
+        }
+    }
+}


### PR DESCRIPTION
I mainly added this because I seen an error log every time the services received this packet. The client sends it every `120000` milliseconds. I didn't add any logic to the handlers at this time. It's probably best that I don't make that decision. In the original binaries, there are some conditions related to the tick count that will disconnect the client. I added some chat codes also, but I'm still working on those. I've allowed edits, because I want you to be able to change things as you see fit.